### PR TITLE
Fix namespace imports in ingredients migration

### DIFF
--- a/database/migrations/2025_09_21_070156_create_ingredients_table.php
+++ b/database/migrations/2025_09_21_070156_create_ingredients_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {


### PR DESCRIPTION
## Summary
- correct the migration's import statements to use proper namespace separators

## Testing
- php -l database/migrations/2025_09_21_070156_create_ingredients_table.php

------
https://chatgpt.com/codex/tasks/task_e_68cfad333674832cadc263f8dd1a605c