### PR TITLE
Ensure admin role keeps ingredient permissions

### DIFF
--- a/database/seeders/RoleTableSeeder.php
+++ b/database/seeders/RoleTableSeeder.php
@@ -32,11 +32,20 @@ class RoleTableSeeder extends Seeder
             ]
         ];
 
-        foreach ($roles as $key => $value) {
-            $permission = $value['permissions'];
+        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+
+        foreach ($roles as $value) {
+            $permissions = $value['permissions'] ?? [];
             unset($value['permissions']);
-            $role = Role::create($value);
-            $role->givePermissionTo($permission);
+
+            $value['guard_name'] = $value['guard_name'] ?? config('auth.defaults.guard');
+
+            $role = Role::updateOrCreate(
+                ['name' => $value['name'], 'guard_name' => $value['guard_name']],
+                $value
+            );
+
+            $role->syncPermissions($permissions);
         }
     }
 }


### PR DESCRIPTION
## Summary
- refresh the permission cache before seeding roles
- update the role seeder to update-or-create roles and sync their permissions so the admin role always receives ingredient abilities

## Testing
- php artisan test *(fails: requires a MySQL connection in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb1d9f2f0832cbcb98586cbde7260