### PR TITLE
Ensure permissions exist before role seeding

### DIFF
--- a/database/seeders/RoleTableSeeder.php
+++ b/database/seeders/RoleTableSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Role;
+use Spatie\Permission\Models\Permission;
 
 class RoleTableSeeder extends Seeder
 {
@@ -39,6 +40,13 @@ class RoleTableSeeder extends Seeder
             unset($value['permissions']);
 
             $value['guard_name'] = $value['guard_name'] ?? config('auth.defaults.guard');
+
+            foreach ($permissions as $permission) {
+                Permission::firstOrCreate(
+                    ['name' => $permission, 'guard_name' => $value['guard_name']],
+                    ['name' => $permission, 'guard_name' => $value['guard_name']]
+                );
+            }
 
             $role = Role::updateOrCreate(
                 ['name' => $value['name'], 'guard_name' => $value['guard_name']],


### PR DESCRIPTION
## Summary
- ensure the role seeder creates any referenced permissions before syncing

## Testing
- php artisan db:seed --class=RoleTableSeeder *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb3a73e94832c971fea4502311749