### PR TITLE
Ensure permission seeder populates titles

### DIFF
--- a/database/seeders/RoleTableSeeder.php
+++ b/database/seeders/RoleTableSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Role;
+use Illuminate\Support\Str;
 use Spatie\Permission\Models\Permission;
 
 class RoleTableSeeder extends Seeder
@@ -42,9 +43,13 @@ class RoleTableSeeder extends Seeder
             $value['guard_name'] = $value['guard_name'] ?? config('auth.defaults.guard');
 
             foreach ($permissions as $permission) {
-                Permission::firstOrCreate(
+                Permission::updateOrCreate(
                     ['name' => $permission, 'guard_name' => $value['guard_name']],
-                    ['name' => $permission, 'guard_name' => $value['guard_name']]
+                    [
+                        'name' => $permission,
+                        'guard_name' => $value['guard_name'],
+                        'title' => $this->formatPermissionTitle($permission),
+                    ]
                 );
             }
 
@@ -55,5 +60,12 @@ class RoleTableSeeder extends Seeder
 
             $role->syncPermissions($permissions);
         }
+    }
+
+    protected function formatPermissionTitle(string $permission): string
+    {
+        return Str::of($permission)
+            ->replace(['-', '_'], ' ')
+            ->title();
     }
 }


### PR DESCRIPTION
## Summary
- populate permission records with a formatted title when seeding roles
- add a helper that converts permission slugs into readable titles

## Testing
- php artisan db:seed --class=RoleTableSeeder *(fails: SQLSTATE[HY000] [2002] Connection refused because the test database is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb46db078832cbf7a50e2d7cada03