### PR TITLE
Add optional description and image upload to ingredient management

### DIFF
--- a/app/DataTables/IngredientDataTable.php
+++ b/app/DataTables/IngredientDataTable.php
@@ -22,6 +22,11 @@ class IngredientDataTable extends DataTable
     {
         return datatables()
             ->eloquent($query)
+            ->addColumn('ingredient_image', function ($query) {
+                $image = getSingleMedia($query, 'ingredient_image');
+
+                return '<img src=' . $image . ' width="40" height="40" class="rounded" />';
+            })
             ->editColumn('protein', function ($query) {
                 return number_format($query->protein, 2);
             })
@@ -57,7 +62,7 @@ class IngredientDataTable extends DataTable
                     $query->orderBy($column_name, $direction);
                 }
             })
-            ->rawColumns(['action']);
+            ->rawColumns(['action', 'ingredient_image']);
     }
 
     /**
@@ -84,6 +89,7 @@ class IngredientDataTable extends DataTable
                 ->searchable(false)
                 ->title(__('message.srno'))
                 ->orderable(false),
+            ['data' => 'ingredient_image', 'name' => 'ingredient_image', 'title' => __('message.image'), 'orderable' => false, 'searchable' => false],
             ['data' => 'title', 'name' => 'title', 'title' => __('message.title')],
             ['data' => 'protein', 'name' => 'protein', 'title' => __('message.protein')],
             ['data' => 'fat', 'name' => 'fat', 'title' => __('message.fat')],

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -21,6 +21,7 @@ use App\Models\User;
 use App\Models\Product;
 use App\Models\Package;
 use App\Models\ProductCategory;
+use App\Models\Ingredient;
 use App\Helpers\AuthHelper;
 use App\Models\AppSetting;
 use App\Models\DefaultKeyword;
@@ -148,6 +149,10 @@ class HomeController extends Controller
             case 'product_image':
                 $data = Product::find($request->id);
                 $message = __('message.msg_removed',[ 'name' => __('message.product') ]);
+                break;
+            case 'ingredient_image':
+                $data = Ingredient::find($request->id);
+                $message = __('message.msg_removed',[ 'name' => __('message.ingredient') ]);
                 break;
             case 'language_image':
                 $data = LanguageList::find($request->id);

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -53,7 +53,14 @@ class IngredientController extends Controller
             return redirect()->back()->withErrors($message);
         }
 
-        Ingredient::create($request->validated());
+        $data = $request->validated();
+        unset($data['ingredient_image']);
+
+        $ingredient = Ingredient::create($data);
+
+        if ($request->hasFile('ingredient_image')) {
+            storeMediaFile($ingredient, $request->ingredient_image, 'ingredient_image');
+        }
 
         return redirect()->route('ingredient.index')->withSuccess(__('message.save_form', ['form' => __('message.ingredient')]));
     }
@@ -85,7 +92,14 @@ class IngredientController extends Controller
         }
 
         $ingredient = Ingredient::findOrFail($id);
-        $ingredient->fill($request->validated())->update();
+        $data = $request->validated();
+        unset($data['ingredient_image']);
+
+        $ingredient->fill($data)->update();
+
+        if ($request->hasFile('ingredient_image')) {
+            storeMediaFile($ingredient, $request->ingredient_image, 'ingredient_image');
+        }
 
         return redirect()->route('ingredient.index')->withSuccess(__('message.update_form', ['form' => __('message.ingredient')]));
     }

--- a/app/Http/Requests/IngredientRequest.php
+++ b/app/Http/Requests/IngredientRequest.php
@@ -25,9 +25,11 @@ class IngredientRequest extends FormRequest
     {
         $rules = [
             'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'protein' => 'required|numeric|min:0',
             'fat' => 'required|numeric|min:0',
             'carbs' => 'required|numeric|min:0',
+            'ingredient_image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg,webp|max:2048',
         ];
 
         return $rules;

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -4,13 +4,16 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
-class Ingredient extends Model
+class Ingredient extends Model implements HasMedia
 {
-    use HasFactory;
+    use HasFactory, InteractsWithMedia;
 
     protected $fillable = [
         'title',
+        'description',
         'protein',
         'fat',
         'carbs',

--- a/database/migrations/2025_09_21_082411_add_description_and_image_to_ingredients_table.php
+++ b/database/migrations/2025_09_21_082411_add_description_and_image_to_ingredients_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            if (!Schema::hasColumn('ingredients', 'description')) {
+                $table->text('description')->nullable()->after('title');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            if (Schema::hasColumn('ingredients', 'description')) {
+                $table->dropColumn('description');
+            }
+        });
+    }
+};

--- a/resources/views/ingredient/form.blade.php
+++ b/resources/views/ingredient/form.blade.php
@@ -2,9 +2,9 @@
     <div>
         <?php $id = $id ?? null;?>
         @if(isset($id))
-            {{ html()->modelForm($data, 'PATCH', route('ingredient.update', $id) )->open() }}
+            {{ html()->modelForm($data, 'PATCH', route('ingredient.update', $id) )->attribute('enctype', 'multipart/form-data')->open() }}
         @else
-            {{ html()->form('POST', route('ingredient.store'))->open() }}
+            {{ html()->form('POST', route('ingredient.store'))->attribute('enctype', 'multipart/form-data')->open() }}
         @endif
         <div class="row">
             <div class="col-lg-12">
@@ -35,6 +35,28 @@
                                 {{ html()->label(__('message.carbs') . ' <span class="text-danger">*</span>', 'carbs')->class('form-control-label') }}
                                 {{ html()->text('carbs')->placeholder(__('message.carbs')." (".__('message.grams').")")->class('form-control')->attribute('required','required')->attribute('inputmode','decimal') }}
                             </div>
+                            <div class="form-group col-md-12">
+                                {{ html()->label(__('message.description'), 'description')->class('form-control-label') }}
+                                {{ html()->textarea('description')->placeholder(__('message.description'))->class('form-control')->attribute('rows', 4) }}
+                            </div>
+                            <div class="form-group col-md-6">
+                                {{ html()->label(__('message.image'), 'ingredient_image')->class('form-control-label') }}
+                                <input class="form-control file-input" type="file" name="ingredient_image" accept="image/*">
+                            </div>
+                            @if(isset($id) && getMediaFileExit($data, 'ingredient_image'))
+                                <div class="col-md-2 mb-2 position-relative">
+                                    <img id="ingredient_image_preview" src="{{ getSingleMedia($data,'ingredient_image') }}" alt="ingredient_image" class="avatar-100 mt-1">
+                                    <a class="text-danger remove-file" href="{{ route('remove.file', ['id' => $data->id, 'type' => 'ingredient_image']) }}" data--submit='confirm_form' data--confirmation='true' data--ajax='true' data-toggle='tooltip'
+                                       title='{{ __("message.remove_file_title" , ["name" =>  __("message.image") ]) }}'
+                                       data-title='{{ __("message.remove_file_title" , ["name" =>  __("message.image") ]) }}'
+                                       data-message='{{ __("message.remove_file_msg") }}'>
+                                        <svg width="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                            <path opacity="0.4" d="M16.34 1.99976H7.67C4.28 1.99976 2 4.37976 2 7.91976V16.0898C2 19.6198 4.28 21.9998 7.67 21.9998H16.34C19.73 21.9998 22 19.6198 22 16.0898V7.91976C22 4.37976 19.73 1.99976 16.34 1.99976Z" fill="currentColor"></path>
+                                            <path d="M15.0158 13.7703L13.2368 11.9923L15.0148 10.2143C15.3568 9.87326 15.3568 9.31826 15.0148 8.97726C14.6728 8.63326 14.1198 8.63426 13.7778 8.97626L11.9988 10.7543L10.2198 8.97426C9.87782 8.63226 9.32382 8.63426 8.98182 8.97426C8.64082 9.31626 8.64082 9.87126 8.98182 10.2123L10.7618 11.9923L8.98582 13.7673C8.64382 14.1093 8.64382 14.6643 8.98582 15.0043C9.15682 15.1763 9.37982 15.2613 9.60382 15.2613C9.82882 15.2613 10.0518 15.1763 10.2228 15.0053L11.9988 13.2293L13.7788 15.0083C13.9498 15.1793 14.1728 15.2643 14.3968 15.2643C14.6208 15.2643 14.8448 15.1783 15.0158 15.0083C15.3578 14.6663 15.3578 14.1123 15.0158 13.7703Z" fill="currentColor"></path>
+                                        </svg>
+                                    </a>
+                                </div>
+                            @endif
                         </div>
                         <hr>
                         {{ html()->submit( __('message.save') )->class('btn btn-md btn-primary float-end') }}


### PR DESCRIPTION
## Summary
- allow ingredients to store an optional description and support image uploads using the media library
- update the ingredient form and listing to handle file uploads and show thumbnails in the table
- add migration for the new description column and enable image deletion through the existing remove-file endpoint

## Testing
- `php artisan test` *(fails: application is not connected to a MySQL instance in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb5b25018832c9b7f35c98e3301ca