### PR TITLE
Fix media file delivery without storage symlink

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Artisan;
 // Packages
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
 
 use App\Http\Controllers\EquipmentController;
 use App\Http\Controllers\CategoryDietController;
@@ -55,9 +56,13 @@ use App\Http\Controllers\SubAdminController;
 
 require __DIR__.'/auth.php';
 
-Route::get('/storage', function () {
-    Artisan::call('storage:link');
-});
+Route::get('storage/{path}', function ($path) {
+    if (Storage::disk('public')->exists($path)) {
+        return Storage::disk('public')->response($path);
+    }
+
+    abort(404);
+})->where('path', '.*');
 
 Route::get('optimize', function () {
     Artisan::call('optimize:clear');


### PR DESCRIPTION
## Summary
- add a catch-all storage route that streams files from the public disk so uploaded media stays accessible
- remove the previous storage:link route dependency and register the Storage facade for the new route

## Testing
- php artisan route:list | grep storage

------
https://chatgpt.com/codex/tasks/task_e_68cfbdb55914832cb7693571c28487ff