### PR TITLE
Add meal time scheduling when assigning diets

### DIFF
--- a/app/Http/Controllers/DietController.php
+++ b/app/Http/Controllers/DietController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\DataTables\DietDataTable;
 use App\Helpers\AuthHelper;
 use App\Models\Diet;
+use App\Models\AssignDiet;
 use App\Models\Ingredient;
 
 use App\Http\Requests\DietRequest;
@@ -82,6 +83,29 @@ class DietController extends Controller
     public function show($id)
     {
         $data = Diet::findOrFail($id);
+    }
+
+    public function servings(Request $request, Diet $diet)
+    {
+        $userId = $request->input('user_id');
+
+        $serveTimes = [];
+
+        if ($userId) {
+            $assignment = AssignDiet::where('diet_id', $diet->id)
+                ->where('user_id', $userId)
+                ->first();
+
+            if ($assignment && is_array($assignment->serve_times)) {
+                $serveTimes = array_values($assignment->serve_times);
+            }
+        }
+
+        return response()->json([
+            'status' => true,
+            'servings' => (int) ($diet->servings ?? 0),
+            'serve_times' => $serveTimes,
+        ]);
     }
 
     /**

--- a/app/Models/AssignDiet.php
+++ b/app/Models/AssignDiet.php
@@ -11,12 +11,13 @@ class AssignDiet extends Model implements HasMedia
 {
     use HasFactory, InteractsWithMedia;
 
-    protected $fillable = ['user_id','diet_id'];
+    protected $fillable = ['user_id','diet_id','serve_times'];
 
     protected $casts = [
-            'user_id'   => 'integer',
-            'diet_id'   => 'integer',
-        ];
+        'user_id'     => 'integer',
+        'diet_id'     => 'integer',
+        'serve_times' => 'array',
+    ];
 
     public function user()
     {

--- a/database/migrations/2024_06_09_000000_add_serve_times_to_assign_diets_table.php
+++ b/database/migrations/2024_06_09_000000_add_serve_times_to_assign_diets_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('assign_diets', function (Blueprint $table) {
+            $table->json('serve_times')->nullable()->after('diet_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('assign_diets', function (Blueprint $table) {
+            $table->dropColumn('serve_times');
+        });
+    }
+};

--- a/resources/lang/ar/message.php
+++ b/resources/lang/ar/message.php
@@ -73,6 +73,8 @@ return [
     'days' => 'أيام',
     'day' => 'يوم',
     'meal_plan' => 'خطة الوجبات',
+    'meal_times' => 'مواعيد الوجبات',
+    'meal_time_number' => 'موعد الوجبة :number',
     'select_meal' => 'اختر وجبة',
     'change_meal' => 'تعديل الوجبة',
     'no_meal_selected' => 'لم يتم اختيار وجبة بعد.',

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -73,6 +73,8 @@ return [
     'days' => 'Days',
     'day' => 'Day',
     'meal_plan' => 'Meal Plan',
+    'meal_times' => 'Meal times',
+    'meal_time_number' => 'Meal time :number',
     'select_meal' => 'Select Meal',
     'change_meal' => 'Change Meal',
     'no_meal_selected' => 'No meal selected yet.',

--- a/resources/views/users/assign-diet-list.blade.php
+++ b/resources/views/users/assign-diet-list.blade.php
@@ -1,10 +1,27 @@
 @if( count($data) > 0 )
     @foreach ($data as $assigndiet)
+        @php
+            $assignment = $assigndiet->userAssignDiet->first();
+            $serveTimes = collect(optional($assignment)->serve_times)->filter()->values();
+        @endphp
         <tr>
-            <td><img src="{{ getSingleMedia($assigndiet, 'diet_image') }}" alt="diet-image"class="bg-soft-primary rounded img-fluid avatar-40 me-3"></td>
+            <td><img src="{{ getSingleMedia($assigndiet, 'diet_image') }}" alt="diet-image" class="bg-soft-primary rounded img-fluid avatar-40 me-3"></td>
             <td>{{ $assigndiet->title }}</td>
             <td>
-            <a class="btn btn-sm btn-icon btn-danger" 
+                @if($serveTimes->isNotEmpty())
+                    <div class="d-flex flex-wrap gap-1">
+                        @foreach($serveTimes as $index => $time)
+                            <span class="badge bg-soft-primary text-dark">
+                                {{ __('message.meal_time_number', ['number' => $index + 1]) }}: {{ $time }}
+                            </span>
+                        @endforeach
+                    </div>
+                @else
+                    <span>-</span>
+                @endif
+            </td>
+            <td>
+                <a class="btn btn-sm btn-icon btn-danger"
                     data-bs-toggle="tooltip" href="{{ route('delete.assigndiet', [ 'diet_id' => $assigndiet->id, 'user_id' => $user_id ]) }}"
                     data--confirmation='true'
                     data--ajax='true'
@@ -13,7 +30,7 @@
                     data-message='{{ __("message.delete_msg") }}'>
                     <span class="btn-inner">
                         <svg width="20" viewBox="0 0 24 24" fill="none"
-                            xmlns="http://www.w3.org/2000/svg" stroke="currentColor"> <path d="M19.3248 9.46826C19.3248 9.46826 18.7818 16.2033 18.4668 19.0403C18.3168 20.3953 17.4798 21.1893 16.1088 21.2143C13.4998 21.2613 10.8878 21.2643 8.27979 21.2093C6.96079 21.1823 6.13779 20.3783 5.99079 19.0473C5.67379 16.1853 5.13379 9.46826 5.13379 9.46826"
+                            xmlns="http://www.w3.org/2000/svg" stroke="currentColor"> <path d="M19.3248 9.46826C19.3248 9.4682618.7818 16.2033 18.4668 19.0403C18.3168 20.3953 17.4798 21.1893 16.1088 21.2143C13.4998 21.2613 10.8878 21.2643 8.27979 21.2093C6.96079 21.1823 6.13779 20.3783 5.99079 19.0473C5.67379 16.1853 5.13379 9.46826 5.13379 9.46826"
                                 stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
                             <path d="M20.708 6.23975H3.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path>
                             <path
@@ -28,8 +45,9 @@
     @endforeach
 @else
     <tr>
-        <td colspan="3">
+        <td colspan="4">
             {{ __('message.not_found_entry', [ 'name' => __('message.diet') ]) }}
         </td>
     </tr>
 @endif
+

--- a/resources/views/users/assign_diet.blade.php
+++ b/resources/views/users/assign_diet.blade.php
@@ -3,7 +3,7 @@
     <div class="row">
         {{ html()->hidden('user_id',$user_id) }}
         <div class="form-group col-md-12">
-            {{ html()->label(__('message.diet').' <span class="text-danger">*</span>') 
+            {{ html()->label(__('message.diet').' <span class="text-danger">*</span>')
             ->class('form-control-label') }}
             {{ html()->select('diet_id', [], old('diet_id'))
                 ->class('select2js form-group diet')
@@ -12,6 +12,7 @@
                 ->attribute('required', 'required') }}
         </div>
     </div>
+    <div class="row g-3 d-none" id="serve-times-container"></div>
     <div class="modal-footer">
         <button type="button" class="btn btn-md btn-secondary" data-bs-dismiss="modal">{{ __('message.close') }}</button>
         <button type="submit" class="btn btn-md btn-primary" id="btn_submit" data-form="ajax" >{{ __('message.save') }}</button>
@@ -22,10 +23,75 @@
         {{ html()->form()->close() }}
     @endif
 <script>
-    $('#diet_id').select2({
-        dropdownParent: $('#formModal'),
-        width: '100%',
-        placeholder: "{{ __('message.select_name',['select' => __('message.parent_permission')]) }}",
-    });
+    (function ($) {
+        const dietSelect = $('#diet_id').select2({
+            dropdownParent: $('#formModal'),
+            width: '100%',
+            placeholder: "{{ __('message.select_name',['select' => __('message.parent_permission')]) }}",
+        });
+
+        const serveTimesContainer = $('#serve-times-container');
+        const userId = @json($user_id);
+        const mealTimeLabelTemplate = @json(__('message.meal_time_number', ['number' => ':number']));
+        const dietServingUrlTemplate = @json(route('diet.servings', ['diet' => ':id']));
+
+        const renderServeTimeInputs = (servings, times) => {
+            serveTimesContainer.empty();
+
+            if (!servings) {
+                serveTimesContainer.addClass('d-none');
+                return;
+            }
+
+            serveTimesContainer.removeClass('d-none');
+
+            const normalizedTimes = Array.isArray(times)
+                ? times
+                : Object.values(times || {});
+
+            for (let index = 0; index < servings; index += 1) {
+                const timeValue = normalizedTimes[index] ?? '';
+                const labelText = mealTimeLabelTemplate.replace(':number', index + 1);
+
+                const column = $('<div>', { class: 'form-group col-md-6' });
+                const label = $('<label>', { class: 'form-control-label', text: labelText });
+                label.append($('<span>', { class: 'text-danger', text: ' *' }));
+
+                const input = $('<input>', {
+                    type: 'time',
+                    class: 'form-control',
+                    name: 'serve_times[]',
+                    required: true,
+                }).val(timeValue);
+
+                column.append(label, input);
+                serveTimesContainer.append(column);
+            }
+        };
+
+        const fetchDietServings = (dietId) => {
+            if (!dietId) {
+                renderServeTimeInputs(0, []);
+                return;
+            }
+
+            serveTimesContainer.removeClass('d-none').html('<div class="col-12 text-center py-2"><span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span></div>');
+
+            const url = dietServingUrlTemplate.replace(':id', dietId);
+
+            $.get(url, { user_id: userId })
+                .done((response) => {
+                    const servings = parseInt(response.servings, 10) || 0;
+                    renderServeTimeInputs(servings, response.serve_times || []);
+                })
+                .fail(() => {
+                    renderServeTimeInputs(0, []);
+                });
+        };
+
+        dietSelect.on('change', function () {
+            fetchDietServings($(this).val());
+        });
+    })(jQuery);
 </script>
 

--- a/resources/views/users/profile.blade.php
+++ b/resources/views/users/profile.blade.php
@@ -273,6 +273,7 @@
                                 <tr>
                                     <th>{{ __('message.image') }}</th>
                                     <th>{{ __('message.title') }}</th>
+                                    <th>{{ __('message.meal_times') }}</th>
                                     <th></th>
                                 </tr>
                             </thead>

--- a/routes/web.php
+++ b/routes/web.php
@@ -131,6 +131,7 @@ Route::group(['middleware' => [ 'auth', 'useractive' ]], function () {
     Route::resource('workouttype', WorkoutTypeController::class);
 
     Route::resource('diet', DietController::class);
+    Route::get('diet/{diet}/servings', [DietController::class, 'servings'])->name('diet.servings');
     Route::resource('ingredient', IngredientController::class);
     Route::resource('category', CategoryController::class);
     


### PR DESCRIPTION
## Summary
- add a JSON column to store per-serving meal times on assigned diets
- capture and validate meal-time inputs when assigning diets to a user
- expose diet serving counts through a new endpoint and render dynamic time inputs and badges in the UI

## Testing
- php artisan test *(fails: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc108e3fc832c84904b13298c9349