### PR TITLE
Fix missing Crisp chat dependencies

### DIFF
--- a/mobapp/lib/screens/live_chat_screen.dart
+++ b/mobapp/lib/screens/live_chat_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:crisp_chat/crisp_chat.dart';
+import 'package:mighty_fitness/extensions/shared_pref.dart';
 import 'package:mighty_fitness/extensions/widgets.dart';
 import 'package:mighty_fitness/main.dart';
 import 'package:mighty_fitness/utils/app_colors.dart';
+import 'package:mighty_fitness/utils/app_constants.dart';
 
 class LiveChatScreen extends StatefulWidget {
   const LiveChatScreen({super.key});


### PR DESCRIPTION
## Summary
- import the shared preferences helper to access getStringAsync
- bring in the Crisp chat website ID constant used by the live chat config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfeb6e75e8832cabec139d75c06797