### PR TITLE
Generate android local.properties from SDK env

### DIFF
--- a/mobapp/android/build.gradle
+++ b/mobapp/android/build.gradle
@@ -1,3 +1,25 @@
+import java.util.Properties
+def ensureLocalProperties() {
+    def localPropertiesFile = rootProject.file('local.properties')
+    if (localPropertiesFile.exists()) {
+        return
+    }
+
+    def sdkDir = System.getenv('ANDROID_SDK_ROOT') ?: System.getenv('ANDROID_HOME')
+    if (sdkDir == null || sdkDir.trim().isEmpty()) {
+        return
+    }
+
+    def properties = new Properties()
+    properties.setProperty('sdk.dir', sdkDir.replace('\\', '\\\\'))
+
+    localPropertiesFile.withWriter('UTF-8') { writer ->
+        properties.store(writer, 'Automatically generated to provide the Android SDK path')
+    }
+}
+
+ensureLocalProperties()
+
 buildscript {
     ext.kotlin_version = '2.0.20'
     repositories {


### PR DESCRIPTION
## Summary
- create the android/local.properties file automatically when SDK environment variables are available
- avoid build failures caused by missing sdk.dir during Gradle evaluation

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68dff19751f4832c8da82b2da852b256