### PR TITLE
Update Android build to Kotlin 2.1.0 and align tooling

### DIFF
--- a/mobapp/android/build.gradle
+++ b/mobapp/android/build.gradle
@@ -21,7 +21,7 @@ def ensureLocalProperties() {
 ensureLocalProperties()
 
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
@@ -29,7 +29,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.6.0'
         classpath 'com.google.gms:google-services:4.4.2'
     }
 }
@@ -38,6 +38,14 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+    configurations.all {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == "org.jetbrains.kotlin") {
+                details.useVersion kotlin_version
+                details.because("Align Kotlin dependencies with the Kotlin Gradle plugin version $kotlin_version")
+            }
+        }
     }
     subprojects {
         afterEvaluate { project ->

--- a/mobapp/android/settings.gradle
+++ b/mobapp/android/settings.gradle
@@ -21,8 +21,8 @@ plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.2"
    // id "com.android.application" version "7.3.0" apply false
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
-    id "com.google.gms.google-services" version "4.3.8" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.google.gms.google-services" version "4.4.2" apply false
     id "org.gradle.toolchains.foojay-resolver-convention" version "0.9.0"
 }
 


### PR DESCRIPTION
## Summary
- upgrade the Android project to use the Kotlin Gradle plugin 2.1.0 and update the Google Services plugin reference
- align the Android Gradle Plugin classpath with the plugin management block and enforce Kotlin dependency version resolution to avoid mismatched stdlib versions

## Testing
- `./gradlew assembleDebug` *(fails: gradlew script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e003d7f2f8832cb60a2df942a4252b