### PR TITLE
Align Kotlin build tools API version

### DIFF
--- a/mobapp/android/gradle.properties
+++ b/mobapp/android/gradle.properties
@@ -4,5 +4,6 @@ android.enableJetifier=false
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+kotlin.buildToolsApiVersion=2.1.0
 
 


### PR DESCRIPTION
## Summary
- set the Kotlin build tools API version to match the Gradle plugin version

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01ad1765c832ca7f2ebbea68c018d