### PR TITLE
Use configureEach when aligning Kotlin dependencies

### DIFF
--- a/mobapp/android/build.gradle
+++ b/mobapp/android/build.gradle
@@ -39,7 +39,7 @@ allprojects {
         google()
         mavenCentral()
     }
-    configurations.all {
+    configurations.configureEach {
         resolutionStrategy.eachDependency { details ->
             if (details.requested.group == "org.jetbrains.kotlin") {
                 details.useVersion kotlin_version


### PR DESCRIPTION
## Summary
- update the Android build script to use configurations.configureEach when applying the Kotlin dependency resolution strategy

## Testing
- not run (Gradle wrapper script is not present in the repository)

------
https://chatgpt.com/codex/tasks/task_e_68e02c95a838832c9df97646776b1aff