### PR TITLE
Fix AdMob initialization crash by setting default app ID

### DIFF
--- a/mobapp/android/app/src/main/AndroidManifest.xml
+++ b/mobapp/android/app/src/main/AndroidManifest.xml
@@ -90,7 +90,7 @@
             android:value="2" />
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="YOUR_ADMOB_APP_ID" />
+            android:value="ca-app-pub-3940256099942544~3347511713" />
 
 
         <!--<meta-data


### PR DESCRIPTION
## Summary
- replace the placeholder AdMob application ID in the Android manifest with Google's official sample ID so the app can launch without crashing when Mobile Ads initializes

## Testing
- not run (Android build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e269b022d0832cb4e1a403e752cbd4