### PR TITLE
Configure mobile app API base URL

### DIFF
--- a/mobapp/lib/utils/app_config.dart
+++ b/mobapp/lib/utils/app_config.dart
@@ -9,7 +9,7 @@ var initialSteps = 0;
 
 //region baseurl
 /// Note: /Add your domain is www.abc.com
-const mBackendURL = "YOUR_DOMAIN_URL";
+const mBackendURL = "http://207.180.239.207/fitt/public";
 
 
 


### PR DESCRIPTION
## Summary
- point the Flutter mobile app configuration to the new backend host so API requests use http://207.180.239.207/fitt/public

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26f351750832c81d0e7d753800015