### PR TITLE
Rename mobile app branding to Micro health

### DIFF
--- a/mobapp/android/app/src/main/AndroidManifest.xml
+++ b/mobapp/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:allowBackup="false"
         android:hardwareAccelerated="false"
         android:icon="@mipmap/ic_launcher"
-        android:label="Mighty Fitness"
+        android:label="Micro health"
         android:largeHeap="true"
         android:usesCleartextTraffic="true"
         tools:replace="android:label">

--- a/mobapp/ios/Runner/Info.plist
+++ b/mobapp/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Mighty Fitness </string>
+	<string>Micro health </string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Mighty Fitness </string>
+	<string>Micro health </string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -52,23 +52,23 @@
 		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
-	<string>Mighty Fitness  app requires access to the Camera to upload your Profile photo.</string>
+	<string>Micro health  app requires access to the Camera to upload your Profile photo.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Mighty Fitness uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
+	<string>Micro health uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Mighty Fitness uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
+	<string>Micro health uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Mighty Fitness uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
+	<string>Micro health uses your location to provide accurate parcel tracking and timely delivery updates. By accessing your address, we ensure that you receive real-time information about your parcels' status and estimated delivery times.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>The Mighty Fitness app uses your device's microphone to enhance your fitness experience. We utilize voice commands for guided workouts, enabling you to interact with the app hands-free. Your microphone is also used for recording workout notes and feedback. We respect your privacy and do not store any audio without your consent.</string>
+	<string>The Micro health app uses your device's microphone to enhance your fitness experience. We utilize voice commands for guided workouts, enabling you to interact with the app hands-free. Your microphone is also used for recording workout notes and feedback. We respect your privacy and do not store any audio without your consent.</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Mighty Fitness application tracks your steps</string>
+	<string>Micro health application tracks your steps</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Mighty Fitness requires access to the photo library to upload your Profile photo.</string>
+	<string>Micro health requires access to the photo library to upload your Profile photo.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Mighty Fitness requires access to the photo library to upload your Profile photo.</string>
+	<string>Micro health requires access to the photo library to upload your Profile photo.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>We use speech recognition to provide voice-controlled workout instructions and track your progress during workouts in the Mighty Fitness app. Access to the microphone is required to ensure accurate and convenient voice interactions with the app.</string>
+	<string>We use speech recognition to provide voice-controlled workout instructions and track your progress during workouts in the Micro health app. Access to the microphone is required to ensure accurate and convenient voice interactions with the app.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/mobapp/lib/components/notification_utils.dart
+++ b/mobapp/lib/components/notification_utils.dart
@@ -122,10 +122,10 @@ Future<NotificationWeekAndTime?> pickSchedule(
       reminderModel.status = 0;
       reminderModel.duration = mTime;
       reminderModel.week = weekdays[currentIndex!];
-      reminderModel.title = "Mighty Fitness";
+      reminderModel.title = "Micro health";
       reminderModel.subTitle = "Testing";
       notificationStore.addToReminder(reminderModel);
-      // return NotificationWeekAndTime(dayOfTheWeek: selectedDay!, timeOfDay: timeOfDay, title: "Mighty Fitness", subTitle: "Testing");
+      // return NotificationWeekAndTime(dayOfTheWeek: selectedDay!, timeOfDay: timeOfDay, title: "Micro health", subTitle: "Testing");
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- update the Android manifest app label to Micro health
- refresh the iOS display name and permission descriptions to use the Micro health branding
- align the reminder notification title with the new brand

## Testing
- not run (branding-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2727954d0832c930ee03ef9bba68d