### PR TITLE
Fix locale detection and guard shared preference writes

### DIFF
--- a/mobapp/lib/languageConfiguration/LanguageDataConstant.dart
+++ b/mobapp/lib/languageConfiguration/LanguageDataConstant.dart
@@ -8,6 +8,7 @@ import 'package:mighty_fitness/utils/app_config.dart';
 
 //import 'package:nb_utils/nb_utils.dart';
 
+import '../extensions/extension_util/string_extensions.dart';
 import '../extensions/shared_pref.dart';
 import '../main.dart';
 import 'LanguageDefaultJson.dart';
@@ -76,17 +77,40 @@ performLanguageOperation(List<LanguageJsonData>? _defaultServerLanguageData) {
 
 List<Locale> getSupportedLocales() {
   print("get supported called");
-  List<Locale> list = [];
+
+  List<Locale> locales = [];
+  Set<String> seenLocales = {};
+
+  void addLocale(Locale locale) {
+    String key = locale.toString();
+    if (seenLocales.add(key)) {
+      locales.add(locale);
+    }
+  }
+
   if (defaultServerLanguageData != null &&
-      defaultServerLanguageData!.length > 0) {
-    for (int index = 0; index < defaultServerLanguageData!.length; index++) {
-      list.add(Locale(defaultServerLanguageData![index].languageCode!,
-          defaultServerLanguageData![index].countryCode!));
+      defaultServerLanguageData!.isNotEmpty) {
+    for (final language in defaultServerLanguageData!) {
+      String languageCode = language.languageCode.validate(value: defaultLanguageCode);
+      String? rawCountryCode = language.countryCode;
+
+      if (rawCountryCode.validate().isNotEmpty) {
+        String normalizedCountryCode = rawCountryCode!
+            .replaceAll('-', '_')
+            .split('_')
+            .last
+            .toUpperCase();
+        addLocale(Locale(languageCode, normalizedCountryCode));
+      }
+
+      addLocale(Locale(languageCode));
     }
   } else {
-    list.add(defaultLanguageLocale);
+    addLocale(defaultLanguageLocale);
+    addLocale(Locale(defaultLanguageLocale.languageCode));
   }
-  return list;
+
+  return locales;
 }
 
 String getContentValueFromKey(int keywordId) {

--- a/mobapp/lib/languageConfiguration/LanguageDefaultJson.dart
+++ b/mobapp/lib/languageConfiguration/LanguageDefaultJson.dart
@@ -1,6 +1,6 @@
 import 'ServerLanguageResponse.dart';
 
 String defaultLanguageCode = "en"; // Set Default language code
-String defaultCountryCode = "en-IN"; // Set Default Language code
+String defaultCountryCode = "IN"; // Set Default Country code
 String defaultKeyNotFoundValue = "KEY_NOT_FOUND"; // Set your own message if key not found
 List<ContentData> defaultLanguageDataKeys = [];

--- a/mobapp/lib/utils/app_common.dart
+++ b/mobapp/lib/utils/app_common.dart
@@ -244,8 +244,11 @@ Future<void> getSettingData() async {
     setValue(HELP_SUPPORT, value.helpSupportUrl.validate());
     setValue(PRIVACY_POLICY, value.helpSupportUrl.validate());
     setValue(TERMS_SERVICE, value.helpSupportUrl.validate());
-    setValue(CRISP_CHAT_ENABLED, value.crisp_chat?.isCrispChatEnabled);
-    setValue(CRISP_CHAT_WEB_SITE_ID, value.crisp_chat?.crispChatWebsiteId);
+    setValue(CRISP_CHAT_ENABLED, value.crisp_chat?.isCrispChatEnabled ?? false);
+    setValue(
+      CRISP_CHAT_WEB_SITE_ID,
+      (value.crisp_chat?.crispChatWebsiteId).validate(),
+    );
 
   });
 }


### PR DESCRIPTION
## Summary
- normalize supported locales returned from configuration to include language-only fallbacks and avoid duplicates
- correct the default country code constant and add the missing string extension import used by locale parsing
- prevent null Crisp Chat values from being saved to shared preferences by providing safe defaults

## Testing
- Not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e36cc68578832cba14233ae75adcfb