### PR TITLE
Fix dashboard API route to return featured products

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -30,7 +30,7 @@ Route::get('language-table-list',[API\LanguageTableController::class, 'getList']
 
 Route::group(['middleware' => ['auth:sanctum']], function () {
 
-    Route::get('dashboard-detail',[ API\DashboardController::class, 'dashboard']);
+    Route::get('dashboard-detail',[ API\DashboardController::class, 'dashboardDetail']);
     Route::post('update-profile', [ API\UserController::class, 'updateProfile']);
     Route::post('change-password', [ API\UserController::class, 'changePassword']);
     Route::post('update-user-status', [ API\UserController::class, 'updateUserStatus']);


### PR DESCRIPTION
## Summary
- point the `dashboard-detail` API route to the controller method that returns the complete dashboard payload including featured products

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3bf79ab74832c9644d6ba6e6928c3