### PR TITLE
Handle numeric JSON values in dashboard models

### DIFF
--- a/mobapp/lib/models/body_part_response.dart
+++ b/mobapp/lib/models/body_part_response.dart
@@ -1,5 +1,12 @@
 import 'pagination_model.dart';
 
+String? _stringFromJson(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString();
+}
+
 class BodyPartResponse {
   Pagination? pagination;
   List<BodyPartModel>? data;
@@ -53,12 +60,12 @@ class BodyPartModel {
 
   BodyPartModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    status = json['status'];
-    description = json['description'];
-    bodypartImage = json['bodypart_image'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    title = _stringFromJson(json['title']);
+    status = _stringFromJson(json['status']);
+    description = _stringFromJson(json['description']);
+    bodypartImage = _stringFromJson(json['bodypart_image']);
+    createdAt = _stringFromJson(json['created_at']);
+    updatedAt = _stringFromJson(json['updated_at']);
     select = json['select'];
   }
 

--- a/mobapp/lib/models/dashboard_response.dart
+++ b/mobapp/lib/models/dashboard_response.dart
@@ -6,6 +6,13 @@ import 'exercise_response.dart';
 import 'level_response.dart';
 import 'product_response.dart';
 
+String? _stringFromJson(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString();
+}
+
 class DashboardResponse {
   List<BodyPartModel>? bodypart;
   List<LevelModel>? level;
@@ -153,23 +160,23 @@ class Diet {
 
   Diet.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    calories = json['calories'];
-    carbs = json['carbs'];
-    protein = json['protein'];
-    fat = json['fat'];
-    servings = json['servings'];
-    totalTime = json['total_time'];
-    isFeatured = json['is_featured'];
-    status = json['status'];
-    ingredients = json['ingredients'];
-    description = json['description'];
-    dietImage = json['diet_image'];
+    title = _stringFromJson(json['title']);
+    calories = _stringFromJson(json['calories']);
+    carbs = _stringFromJson(json['carbs']);
+    protein = _stringFromJson(json['protein']);
+    fat = _stringFromJson(json['fat']);
+    servings = _stringFromJson(json['servings']);
+    totalTime = _stringFromJson(json['total_time']);
+    isFeatured = _stringFromJson(json['is_featured']);
+    status = _stringFromJson(json['status']);
+    ingredients = _stringFromJson(json['ingredients']);
+    description = _stringFromJson(json['description']);
+    dietImage = _stringFromJson(json['diet_image']);
     isPremium = json['is_premium'];
     categorydietId = json['categorydiet_id'];
-    categorydietTitle = json['categorydiet_title'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    categorydietTitle = _stringFromJson(json['categorydiet_title']);
+    createdAt = _stringFromJson(json['created_at']);
+    updatedAt = _stringFromJson(json['updated_at']);
     isFavourite = json['is_favourite'];
   }
 

--- a/mobapp/lib/models/equipment_response.dart
+++ b/mobapp/lib/models/equipment_response.dart
@@ -1,5 +1,12 @@
 import '../../models/pagination_model.dart';
 
+String? _stringFromJson(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString();
+}
+
 class EquipmentResponse {
   Pagination? pagination;
   List<EquipmentModel>? data;
@@ -42,12 +49,12 @@ class EquipmentModel {
 
   EquipmentModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    status = json['status'];
-    description = json['description'];
-    equipmentImage = json['equipment_image'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    title = _stringFromJson(json['title']);
+    status = _stringFromJson(json['status']);
+    description = _stringFromJson(json['description']);
+    equipmentImage = _stringFromJson(json['equipment_image']);
+    createdAt = _stringFromJson(json['created_at']);
+    updatedAt = _stringFromJson(json['updated_at']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/exercise_response.dart
+++ b/mobapp/lib/models/exercise_response.dart
@@ -1,5 +1,12 @@
 import '../models/pagination_model.dart';
 
+String? _stringFromJson(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString();
+}
+
 class ExerciseResponse {
   Pagination? pagination;
   List<ExerciseModel>? data;
@@ -77,19 +84,19 @@ class ExerciseModel {
 
   ExerciseModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    status = json['status'];
+    title = _stringFromJson(json['title']);
+    status = _stringFromJson(json['status']);
     isPremium = json['is_premium'];
-    exerciseImage = json['exercise_image'];
-    videoType = json['video_type'];
-    videoUrl = json['video_url'];
+    exerciseImage = _stringFromJson(json['exercise_image']);
+    videoType = _stringFromJson(json['video_type']);
+    videoUrl = _stringFromJson(json['video_url']);
     if (json['bodypart_name'] != null) {
       bodypartName = <BodypartName>[];
       json['bodypart_name'].forEach((v) {
         bodypartName!.add(new BodypartName.fromJson(v));
       });
     }
-    duration = json['duration'];
+    duration = _stringFromJson(json['duration']);
     if (json['sets'] != null) {
       sets = <Sets>[];
       json['sets'].forEach((v) {
@@ -97,15 +104,15 @@ class ExerciseModel {
       });
     }
     equipmentId = json['equipment_id'];
-    equipmentTitle = json['equipment_title'];
+    equipmentTitle = _stringFromJson(json['equipment_title']);
     levelId = json['level_id'];
-    levelTitle = json['level_title'];
-    instruction = json['instruction'];
-    tips = json['tips'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
-    type = json['type'];
-    based = json['based'];
+    levelTitle = _stringFromJson(json['level_title']);
+    instruction = _stringFromJson(json['instruction']);
+    tips = _stringFromJson(json['tips']);
+    createdAt = _stringFromJson(json['created_at']);
+    updatedAt = _stringFromJson(json['updated_at']);
+    type = _stringFromJson(json['type']);
+    based = _stringFromJson(json['based']);
   }
 
   Map<String, dynamic> toJson() {
@@ -148,8 +155,8 @@ class BodypartName {
 
   BodypartName.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    bodypartImage = json['bodypart_image'];
+    title = _stringFromJson(json['title']);
+    bodypartImage = _stringFromJson(json['bodypart_image']);
   }
 
   Map<String, dynamic> toJson() {
@@ -170,10 +177,10 @@ class Sets {
   Sets({this.reps, this.rest, this.time, this.weight});
 
   Sets.fromJson(Map<String, dynamic> json) {
-    reps = json['reps'];
-    rest = json['rest'];
-    time = json['time'];
-    weight = json['weight'];
+    reps = _stringFromJson(json['reps']);
+    rest = _stringFromJson(json['rest']);
+    time = _stringFromJson(json['time']);
+    weight = _stringFromJson(json['weight']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/level_response.dart
+++ b/mobapp/lib/models/level_response.dart
@@ -1,5 +1,12 @@
 import 'pagination_model.dart';
 
+String? _stringFromJson(dynamic value) {
+  if (value == null) {
+    return null;
+  }
+  return value.toString();
+}
+
 class LevelResponse {
   Pagination? pagination;
   List<LevelModel>? data;
@@ -51,12 +58,12 @@ class LevelModel {
 
   LevelModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
+    title = _stringFromJson(json['title']);
     rate = json['rate'];
-    status = json['status'];
-    levelImage = json['level_image'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    status = _stringFromJson(json['status']);
+    levelImage = _stringFromJson(json['level_image']);
+    createdAt = _stringFromJson(json['created_at']);
+    updatedAt = _stringFromJson(json['updated_at']);
   }
 
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
## Summary
- normalize dashboard-related model parsing so numeric values are converted to strings when necessary
- avoid runtime type errors by adding shared helpers in each model file

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c1e4decc832c87960a4918aff65d