### PR TITLE
Handle localized API strings on mobile dashboard

### DIFF
--- a/mobapp/lib/models/body_part_response.dart
+++ b/mobapp/lib/models/body_part_response.dart
@@ -1,11 +1,5 @@
+import '../utils/json_utils.dart';
 import 'pagination_model.dart';
-
-String? _stringFromJson(dynamic value) {
-  if (value == null) {
-    return null;
-  }
-  return value.toString();
-}
 
 class BodyPartResponse {
   Pagination? pagination;
@@ -60,12 +54,12 @@ class BodyPartModel {
 
   BodyPartModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
-    status = _stringFromJson(json['status']);
-    description = _stringFromJson(json['description']);
-    bodypartImage = _stringFromJson(json['bodypart_image']);
-    createdAt = _stringFromJson(json['created_at']);
-    updatedAt = _stringFromJson(json['updated_at']);
+    title = parseStringFromJson(json['title']);
+    status = parseStringFromJson(json['status']);
+    description = parseStringFromJson(json['description']);
+    bodypartImage = parseStringFromJson(json['bodypart_image']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
     select = json['select'];
   }
 

--- a/mobapp/lib/models/dashboard_response.dart
+++ b/mobapp/lib/models/dashboard_response.dart
@@ -1,17 +1,11 @@
 import '../models/workout_detail_response.dart';
+import '../utils/json_utils.dart';
 
 import 'body_part_response.dart';
 import 'equipment_response.dart';
 import 'exercise_response.dart';
 import 'level_response.dart';
 import 'product_response.dart';
-
-String? _stringFromJson(dynamic value) {
-  if (value == null) {
-    return null;
-  }
-  return value.toString();
-}
 
 class DashboardResponse {
   List<BodyPartModel>? bodypart;
@@ -160,23 +154,23 @@ class Diet {
 
   Diet.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
-    calories = _stringFromJson(json['calories']);
-    carbs = _stringFromJson(json['carbs']);
-    protein = _stringFromJson(json['protein']);
-    fat = _stringFromJson(json['fat']);
-    servings = _stringFromJson(json['servings']);
-    totalTime = _stringFromJson(json['total_time']);
-    isFeatured = _stringFromJson(json['is_featured']);
-    status = _stringFromJson(json['status']);
-    ingredients = _stringFromJson(json['ingredients']);
-    description = _stringFromJson(json['description']);
-    dietImage = _stringFromJson(json['diet_image']);
+    title = parseStringFromJson(json['title']);
+    calories = parseStringFromJson(json['calories']);
+    carbs = parseStringFromJson(json['carbs']);
+    protein = parseStringFromJson(json['protein']);
+    fat = parseStringFromJson(json['fat']);
+    servings = parseStringFromJson(json['servings']);
+    totalTime = parseStringFromJson(json['total_time']);
+    isFeatured = parseStringFromJson(json['is_featured']);
+    status = parseStringFromJson(json['status']);
+    ingredients = parseStringFromJson(json['ingredients']);
+    description = parseStringFromJson(json['description']);
+    dietImage = parseStringFromJson(json['diet_image']);
     isPremium = json['is_premium'];
     categorydietId = json['categorydiet_id'];
-    categorydietTitle = _stringFromJson(json['categorydiet_title']);
-    createdAt = _stringFromJson(json['created_at']);
-    updatedAt = _stringFromJson(json['updated_at']);
+    categorydietTitle = parseStringFromJson(json['categorydiet_title']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
     isFavourite = json['is_favourite'];
   }
 
@@ -216,10 +210,10 @@ class Workouttype {
 
   Workouttype.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    status = json['status'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    title = parseStringFromJson(json['title']);
+    status = parseStringFromJson(json['status']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/equipment_response.dart
+++ b/mobapp/lib/models/equipment_response.dart
@@ -1,11 +1,5 @@
+import '../utils/json_utils.dart';
 import '../../models/pagination_model.dart';
-
-String? _stringFromJson(dynamic value) {
-  if (value == null) {
-    return null;
-  }
-  return value.toString();
-}
 
 class EquipmentResponse {
   Pagination? pagination;
@@ -49,12 +43,12 @@ class EquipmentModel {
 
   EquipmentModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
-    status = _stringFromJson(json['status']);
-    description = _stringFromJson(json['description']);
-    equipmentImage = _stringFromJson(json['equipment_image']);
-    createdAt = _stringFromJson(json['created_at']);
-    updatedAt = _stringFromJson(json['updated_at']);
+    title = parseStringFromJson(json['title']);
+    status = parseStringFromJson(json['status']);
+    description = parseStringFromJson(json['description']);
+    equipmentImage = parseStringFromJson(json['equipment_image']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/exercise_response.dart
+++ b/mobapp/lib/models/exercise_response.dart
@@ -1,11 +1,5 @@
+import '../utils/json_utils.dart';
 import '../models/pagination_model.dart';
-
-String? _stringFromJson(dynamic value) {
-  if (value == null) {
-    return null;
-  }
-  return value.toString();
-}
 
 class ExerciseResponse {
   Pagination? pagination;
@@ -84,19 +78,19 @@ class ExerciseModel {
 
   ExerciseModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
-    status = _stringFromJson(json['status']);
+    title = parseStringFromJson(json['title']);
+    status = parseStringFromJson(json['status']);
     isPremium = json['is_premium'];
-    exerciseImage = _stringFromJson(json['exercise_image']);
-    videoType = _stringFromJson(json['video_type']);
-    videoUrl = _stringFromJson(json['video_url']);
+    exerciseImage = parseStringFromJson(json['exercise_image']);
+    videoType = parseStringFromJson(json['video_type']);
+    videoUrl = parseStringFromJson(json['video_url']);
     if (json['bodypart_name'] != null) {
       bodypartName = <BodypartName>[];
       json['bodypart_name'].forEach((v) {
         bodypartName!.add(new BodypartName.fromJson(v));
       });
     }
-    duration = _stringFromJson(json['duration']);
+    duration = parseStringFromJson(json['duration']);
     if (json['sets'] != null) {
       sets = <Sets>[];
       json['sets'].forEach((v) {
@@ -104,15 +98,15 @@ class ExerciseModel {
       });
     }
     equipmentId = json['equipment_id'];
-    equipmentTitle = _stringFromJson(json['equipment_title']);
+    equipmentTitle = parseStringFromJson(json['equipment_title']);
     levelId = json['level_id'];
-    levelTitle = _stringFromJson(json['level_title']);
-    instruction = _stringFromJson(json['instruction']);
-    tips = _stringFromJson(json['tips']);
-    createdAt = _stringFromJson(json['created_at']);
-    updatedAt = _stringFromJson(json['updated_at']);
-    type = _stringFromJson(json['type']);
-    based = _stringFromJson(json['based']);
+    levelTitle = parseStringFromJson(json['level_title']);
+    instruction = parseStringFromJson(json['instruction']);
+    tips = parseStringFromJson(json['tips']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
+    type = parseStringFromJson(json['type']);
+    based = parseStringFromJson(json['based']);
   }
 
   Map<String, dynamic> toJson() {
@@ -155,8 +149,8 @@ class BodypartName {
 
   BodypartName.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
-    bodypartImage = _stringFromJson(json['bodypart_image']);
+    title = parseStringFromJson(json['title']);
+    bodypartImage = parseStringFromJson(json['bodypart_image']);
   }
 
   Map<String, dynamic> toJson() {
@@ -177,10 +171,10 @@ class Sets {
   Sets({this.reps, this.rest, this.time, this.weight});
 
   Sets.fromJson(Map<String, dynamic> json) {
-    reps = _stringFromJson(json['reps']);
-    rest = _stringFromJson(json['rest']);
-    time = _stringFromJson(json['time']);
-    weight = _stringFromJson(json['weight']);
+    reps = parseStringFromJson(json['reps']);
+    rest = parseStringFromJson(json['rest']);
+    time = parseStringFromJson(json['time']);
+    weight = parseStringFromJson(json['weight']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/level_response.dart
+++ b/mobapp/lib/models/level_response.dart
@@ -1,11 +1,5 @@
+import '../utils/json_utils.dart';
 import 'pagination_model.dart';
-
-String? _stringFromJson(dynamic value) {
-  if (value == null) {
-    return null;
-  }
-  return value.toString();
-}
 
 class LevelResponse {
   Pagination? pagination;
@@ -58,12 +52,12 @@ class LevelModel {
 
   LevelModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = _stringFromJson(json['title']);
+    title = parseStringFromJson(json['title']);
     rate = json['rate'];
-    status = _stringFromJson(json['status']);
-    levelImage = _stringFromJson(json['level_image']);
-    createdAt = _stringFromJson(json['created_at']);
-    updatedAt = _stringFromJson(json['updated_at']);
+    status = parseStringFromJson(json['status']);
+    levelImage = parseStringFromJson(json['level_image']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
   }
 
   Map<String, dynamic> toJson() {

--- a/mobapp/lib/models/product_response.dart
+++ b/mobapp/lib/models/product_response.dart
@@ -1,4 +1,5 @@
 
+import '../utils/json_utils.dart';
 import '../models/pagination_model.dart';
 
 class ProductResponse {
@@ -72,9 +73,9 @@ class ProductModel {
 
   ProductModel.fromJson(Map<String, dynamic> json) {
     id = json['id'];
-    title = json['title'];
-    description = json['description'];
-    affiliateLink = json['affiliate_link'];
+    title = parseStringFromJson(json['title']);
+    description = parseStringFromJson(json['description']);
+    affiliateLink = parseStringFromJson(json['affiliate_link']);
     price = json['price'];
     finalPrice = json['final_price'] != null ? num.tryParse(json['final_price'].toString()) : null;
     discountPrice = json['discount_price'] != null ? num.tryParse(json['discount_price'].toString()) : null;
@@ -82,15 +83,16 @@ class ProductModel {
     discountActive = json['discount_active'] == true || json['discount_active'] == 1;
     productcategoryId = json['productcategory_id'];
     if (json['productcategory_title'] != null) {
-      productcategoryTitle = json['productcategory_title'];
+      productcategoryTitle = parseStringFromJson(json['productcategory_title']);
     } else if (json['productcategory'] is Map<String, dynamic>) {
-      productcategoryTitle = (json['productcategory'] as Map<String, dynamic>)['title'];
+      productcategoryTitle = parseStringFromJson(
+          (json['productcategory'] as Map<String, dynamic>)['title']);
     }
-    featured = json['featured'];
-    status = json['status'];
-    productImage = json['product_image'];
-    createdAt = json['created_at'];
-    updatedAt = json['updated_at'];
+    featured = parseStringFromJson(json['featured']);
+    status = parseStringFromJson(json['status']);
+    productImage = parseStringFromJson(json['product_image']);
+    createdAt = parseStringFromJson(json['created_at']);
+    updatedAt = parseStringFromJson(json['updated_at']);
     isFavourite = json['is_favourite'] == true || json['is_favourite'] == 1;
     isInCart = json['is_in_cart'] == true || json['is_in_cart'] == 1;
     cartQuantity = json['cart_quantity'] != null ? (json['cart_quantity'] as num).toInt() : 0;

--- a/mobapp/lib/utils/json_utils.dart
+++ b/mobapp/lib/utils/json_utils.dart
@@ -1,0 +1,58 @@
+import '../extensions/extension_util/string_extensions.dart';
+import '../languageConfiguration/LanguageDefaultJson.dart';
+import '../main.dart';
+
+/// Safely converts dynamic values returned from the API into a String.
+///
+/// The backend can return raw strings, numbers, booleans, localized maps or
+/// even lists for certain fields. This helper normalises all of these cases to
+/// a readable string while respecting the selected application language.
+String? parseStringFromJson(dynamic value) {
+  if (value == null) return null;
+
+  if (value is String) return value;
+  if (value is num || value is bool) return value.toString();
+
+  if (value is Map) {
+    final normalizedSelectedLanguage =
+        appStore.selectedLanguageCode.validate(value: defaultLanguageCode).toLowerCase();
+    final possibleLanguageKeys = <String>{
+      normalizedSelectedLanguage,
+      defaultLanguageCode.toLowerCase(),
+      'en',
+    };
+
+    for (final key in possibleLanguageKeys) {
+      final match = value.entries.firstWhere(
+        (entry) => entry.key.toString().toLowerCase() == key,
+        orElse: () => MapEntry('', null),
+      );
+
+      if (match.value != null) {
+        final matchValue = match.value;
+        if (matchValue is String) return matchValue;
+        if (matchValue is num || matchValue is bool) return matchValue.toString();
+      }
+    }
+
+    for (final mapValue in value.values) {
+      if (mapValue == null) continue;
+      if (mapValue is String) return mapValue;
+      if (mapValue is num || mapValue is bool) return mapValue.toString();
+    }
+
+    return value.toString();
+  }
+
+  if (value is Iterable) {
+    final buffer = <String>[];
+    for (final element in value) {
+      final parsed = parseStringFromJson(element);
+      final normalized = parsed.validate();
+      if (normalized.isNotEmpty) buffer.add(normalized);
+    }
+    if (buffer.isNotEmpty) return buffer.join(', ');
+  }
+
+  return value.toString();
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to normalise API values into strings while respecting the selected language
- update dashboard, body part, equipment, level, exercise and product models to use the new helper
- ensure product parsing supports dynamic category titles and other string fields without runtime type errors

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cadb0024832cbefb87b6c5377754