### PR TITLE
Fix auth session helper to refresh user permissions

### DIFF
--- a/app/Helpers/AuthHelper.php
+++ b/app/Helpers/AuthHelper.php
@@ -8,15 +8,15 @@ use Illuminate\Support\Facades\Auth;
 
 class AuthHelper {
     public static function authSession(){
-        $session = new \App\Models\User;
-        if(Session::has('auth_user')){
-            $session = Session::get('auth_user');
-        }else{
-            $user = Auth::user();
-            Session::put('auth_user',$user);
-            $session = Session::get('auth_user');
+        if (Auth::check()) {
+            return Auth::user()->fresh();
         }
-        return $session;
+
+        if (Session::has('auth_user')) {
+            return Session::get('auth_user');
+        }
+
+        return new \App\Models\User;
     }
 
     public static function checkMenuRoleAndPermission($menu)


### PR DESCRIPTION
## Summary
- ensure the authenticated user instance is refreshed instead of relying on a cached session copy
- fall back to any stored session user or a blank model when no authenticated user exists

## Testing
- php artisan test *(fails: Please provide a valid cache path)*

------
https://chatgpt.com/codex/tasks/task_e_68e3df891718832cb831a7c8db2a7a8e