### PR TITLE
Allow parent banner permission to unlock module access

### DIFF
--- a/app/Http/Controllers/BannerController.php
+++ b/app/Http/Controllers/BannerController.php
@@ -14,13 +14,13 @@ class BannerController extends Controller
         $pageTitle = __('message.list_form_title', ['form' => __('message.banner')]);
         $authUser = AuthHelper::authSession();
 
-        if (!$authUser->can('banner-list')) {
+        if (!$authUser->hasAnyPermission(['banner-list', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }
 
         $assets = ['data-table'];
-        $headerAction = $authUser->can('banner-add')
+        $headerAction = $authUser->hasAnyPermission(['banner-add', 'banner'])
             ? '<a href="' . route('banner.create') . '" class="btn btn-sm btn-primary" role="button">' . __('message.add_form_title', ['form' => __('message.banner')]) . '</a>'
             : '';
 
@@ -29,7 +29,7 @@ class BannerController extends Controller
 
     public function create()
     {
-        if (!auth()->user()->can('banner-add')) {
+        if (!auth()->user()->hasAnyPermission(['banner-add', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }
@@ -40,7 +40,7 @@ class BannerController extends Controller
 
     public function store(BannerRequest $request)
     {
-        if (!auth()->user()->can('banner-add')) {
+        if (!auth()->user()->hasAnyPermission(['banner-add', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }
@@ -55,7 +55,7 @@ class BannerController extends Controller
 
     public function edit($id)
     {
-        if (!auth()->user()->can('banner-edit')) {
+        if (!auth()->user()->hasAnyPermission(['banner-edit', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }
@@ -68,7 +68,7 @@ class BannerController extends Controller
 
     public function update(BannerRequest $request, $id)
     {
-        if (!auth()->user()->can('banner-edit')) {
+        if (!auth()->user()->hasAnyPermission(['banner-edit', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }
@@ -91,7 +91,7 @@ class BannerController extends Controller
 
     public function destroy($id)
     {
-        if (!auth()->user()->can('banner-delete')) {
+        if (!auth()->user()->hasAnyPermission(['banner-delete', 'banner'])) {
             $message = __('message.permission_denied_for_account');
             return redirect()->back()->withErrors($message);
         }

--- a/resources/views/banner/action.blade.php
+++ b/resources/views/banner/action.blade.php
@@ -3,7 +3,7 @@
 ?>
 
 <div class="d-flex align-items-center">
-    @if($auth_user->can('banner-edit'))
+    @if($auth_user->hasAnyPermission(['banner-edit', 'banner']))
         <a class="btn btn-sm btn-icon btn-success me-2" href="{{ route('banner.edit', $id) }}" data-bs-toggle="tooltip"
            title="{{ __('message.update_form_title',['form' => __('message.banner') ]) }}">
             <span class="btn-inner">
@@ -15,7 +15,7 @@
             </span>
         </a>
     @endif
-    @if($auth_user->can('banner-delete'))
+    @if($auth_user->hasAnyPermission(['banner-delete', 'banner']))
         {{ html()->form('POST', route('banner.destroy', $id))->attribute('data--submit', 'banner-delete'.$id)->attribute('data--confirmation', 'true')->attribute('data-title', __('message.delete_form_title', [ 'form'=> __('message.banner') ]))->attribute('data-message', __('message.delete_msg'))->open() }}
         {{ html()->hidden('_method')->value('DELETE') }}
             <a class="btn btn-sm btn-icon btn-danger" href="javascript:void(0)" data-bs-toggle="tooltip" data--submit="banner-delete{{$id}}"


### PR DESCRIPTION
## Summary
- allow the generic `banner` permission to satisfy the controller checks that guard banner CRUD pages
- update the banner action buttons so users with only the parent banner permission can still edit or delete records

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3e2e4359c832c93bb9e585174652b