### PR TITLE
Allow admin role to manage banner actions

### DIFF
--- a/resources/views/banner/action.blade.php
+++ b/resources/views/banner/action.blade.php
@@ -3,7 +3,7 @@
 ?>
 
 <div class="d-flex align-items-center">
-    @if($auth_user && ($auth_user->can('banner-edit') || $auth_user->can('banner')))
+    @if($auth_user && ($auth_user->hasRole('admin') || $auth_user->can('banner-edit') || $auth_user->can('banner')))
         <a class="btn btn-sm btn-icon btn-success me-2" href="{{ route('banner.edit', $id) }}" data-bs-toggle="tooltip"
            title="{{ __('message.update_form_title',['form' => __('message.banner') ]) }}">
             <span class="btn-inner">
@@ -15,7 +15,7 @@
             </span>
         </a>
     @endif
-    @if($auth_user && ($auth_user->can('banner-delete') || $auth_user->can('banner')))
+    @if($auth_user && ($auth_user->hasRole('admin') || $auth_user->can('banner-delete') || $auth_user->can('banner')))
         {{ html()->form('POST', route('banner.destroy', $id))->attribute('data--submit', 'banner-delete'.$id)->open() }}
         {{ html()->hidden('_method', 'DELETE') }}
             <a class="btn btn-sm btn-icon btn-danger" href="javascript:void(0)" data-bs-toggle="tooltip" data--submit="banner-delete{{$id}}"


### PR DESCRIPTION
## Summary
- allow admin users to see banner edit and delete actions without requiring additional permissions

## Testing
- php artisan test *(fails: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ed7fe2b0832ca1220d96e7c93817