### PR TITLE
Add product category and discount sections to home screen

### DIFF
--- a/mobapp/assets/fitness_language.json
+++ b/mobapp/assets/fitness_language.json
@@ -443,6 +443,12 @@
       },
       {
         "screenId": "8",
+        "keyword_id": 263,
+        "keyword_name": "lblExclusiveDiscounts",
+        "keyword_value": "Exclusive discounts"
+      },
+      {
+        "screenId": "8",
         "keyword_id": 246,
         "keyword_name": "lblUpdateNow",
         "keyword_value": "Update Now"

--- a/mobapp/lib/languageConfiguration/BaseLanguage.dart
+++ b/mobapp/lib/languageConfiguration/BaseLanguage.dart
@@ -166,6 +166,7 @@ class BaseLanguage {
   String get lblProductList=> getContentValueFromKey(99);
 
   String get lblSelectedProductsForYou => getContentValueFromKey(249);
+  String get lblExclusiveDiscounts => getContentValueFromKey(263);
   String get lblSuccessStories => getContentValueFromKey(260);
   String get lblBefore => getContentValueFromKey(261);
   String get lblAfter => getContentValueFromKey(262);


### PR DESCRIPTION
## Summary
- show product categories under the featured products carousel and open the relevant listing on tap
- surface an exclusive discounts strip populated from discounted products and reuse it in the dashboard helpers
- extend the product listing screen to filter discounted items and add the supporting localization string

## Testing
- flutter test *(fails: Flutter SDK not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e409425fb0832ca68a22603734e6da