### PR TITLE
Fix deprecated text theme usage in offer dialog

### DIFF
--- a/mobapp/lib/components/exclusive_offer_dialog.dart
+++ b/mobapp/lib/components/exclusive_offer_dialog.dart
@@ -19,6 +19,8 @@ Future<void> showExclusiveOfferDialog(BuildContext context, ExclusiveOfferModel 
     builder: (ctx) {
       final textTheme = Theme.of(ctx).textTheme;
       final buttonTextStyle = textTheme.labelLarge ?? const TextStyle(fontSize: 16);
+      final titleTextStyle = textTheme.titleLarge ?? textTheme.headlineSmall;
+      final bodyTextColor = textTheme.bodyMedium?.color ?? Colors.black87;
 
       return Dialog(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
@@ -61,14 +63,14 @@ Future<void> showExclusiveOfferDialog(BuildContext context, ExclusiveOfferModel 
                 if (offer.title.validate().isNotEmpty)
                   Text(
                     offer.title.validate(),
-                    style: textTheme.headline6?.copyWith(fontWeight: FontWeight.w600),
+                    style: titleTextStyle?.copyWith(fontWeight: FontWeight.w600),
                     textAlign: TextAlign.center,
                   ),
                 if (offer.description.validate().isNotEmpty) ...[
                   const SizedBox(height: 12),
                   Text(
                     offer.description.validate(),
-                    style: primaryTextStyle(size: 14, color: context.bodyTextColor),
+                    style: primaryTextStyle(size: 14, color: bodyTextColor),
                     textAlign: TextAlign.center,
                   ),
                 ],


### PR DESCRIPTION
## Summary
- derive dialog title style from modern text theme fields
- use body text color from the active theme instead of removed context extension

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e413bc8ee4832cabe5762155329f25