### PR TITLE
Fix specialist directory null branch access

### DIFF
--- a/resources/views/users/profile.blade.php
+++ b/resources/views/users/profile.blade.php
@@ -25,7 +25,7 @@
             return [
                 (string) $specialist->id => [
                     'name' => $specialist->name,
-                    'branch' => $specialist->branch?->name,
+                    'branch' => optional($specialist->branch)->name,
                     'phone' => $specialist->phone,
                     'email' => $specialist->email,
                 ],


### PR DESCRIPTION
## Summary
- use Laravel's optional helper when serializing specialist branches for the profile view to avoid nullsafe operator syntax issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e42102ac74832cb7a196496b5c411e