### PR TITLE
Precompute specialist directory before JSON encoding

### DIFF
--- a/resources/views/users/profile.blade.php
+++ b/resources/views/users/profile.blade.php
@@ -21,16 +21,20 @@
                 }
             });
         }
-        const specialistDirectory = @json($specialists->mapWithKeys(function ($specialist) {
-            return [
-                (string) $specialist->id => [
-                    'name' => $specialist->name,
-                    'branch' => $specialist->branch?->name,
-                    'phone' => $specialist->phone,
-                    'email' => $specialist->email,
-                ],
-            ];
-        }));
+        @php
+            $specialistDirectory = $specialists->mapWithKeys(function ($specialist) {
+                return [
+                    (string) $specialist->id => [
+                        'name' => $specialist->name,
+                        'branch' => optional($specialist->branch)->name,
+                        'phone' => $specialist->phone,
+                        'email' => $specialist->email,
+                    ],
+                ];
+            })->toArray();
+        @endphp
+
+        const specialistDirectory = @json($specialistDirectory);
 
         function renderSpecialistDetails(specialistId) {
             const container = $('#specialist-details');


### PR DESCRIPTION
## Summary
- precompute the specialist directory array in PHP before embedding it as JSON in the profile view to avoid Blade parsing errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42102ac74832cb7a196496b5c411e