### PR TITLE
Switch default currency to Jordanian dinar

### DIFF
--- a/app/Helpers/helper.php
+++ b/app/Helpers/helper.php
@@ -427,10 +427,10 @@ function getPriceFormat($price)
         $price = 0;
     }
     
-    $currency_code = SettingData('CURRENCY', 'CURRENCY_CODE') ?? 'USD';
+    $currency_code = SettingData('CURRENCY', 'CURRENCY_CODE') ?? 'JOD';
     $currecy = currencyArray($currency_code);
 
-    $code = $currecy['symbol'] ?? '$';
+    $code = $currecy['symbol'] ?? 'د.ا';
     $position = SettingData('CURRENCY', 'CURRENCY_POSITION') ?? 'left';
     
     if ($position == 'left') {

--- a/app/Http/Controllers/API/DashboardController.php
+++ b/app/Http/Controllers/API/DashboardController.php
@@ -122,12 +122,12 @@ class DashboardController extends Controller
         $response = [
             'data' => $setting,
         ];
-        $currency_code = SettingData('CURRENCY', 'CURRENCY_CODE') ?? 'USD';
+        $currency_code = SettingData('CURRENCY', 'CURRENCY_CODE') ?? 'JOD';
         $currency = currencyArray($currency_code);
         $response['currency_setting'] = [
-            'name' => $currency['name'] ?? 'United States (US) dollar',
-            'symbol' => $currency['symbol'] ?? '$',
-            'code' => strtolower($currency['code']) ?? 'usd',
+            'name' => $currency['name'] ?? 'Jordanian dinar',
+            'symbol' => $currency['symbol'] ?? 'د.ا',
+            'code' => strtolower($currency['code']) ?? 'jod',
             'position' => SettingData('CURRENCY', 'CURRENCY_POSITION') ?? 'left',
         ];
 

--- a/resources/views/setting/mobile-config.blade.php
+++ b/resources/views/setting/mobile-config.blade.php
@@ -40,7 +40,7 @@
                                     <input type="hidden" name="key[]" value="{{ $key.'_'.$sub_keys }}">
                                     @if($key == 'CURRENCY' && $sub_keys == 'CODE')
                                         @php
-                                            $currency_code = $data->value ?? 'USD';
+                                            $currency_code = $data->value ?? 'JOD';
                                             $currency = currencyArray($currency_code);
                                         @endphp
                                         <select class="form-control select2js" name="value[]" id="{{ $key.'_'.$sub_keys }}">


### PR DESCRIPTION
## Summary
- change the default currency code to JOD so prices display in Jordanian dinars
- adjust API currency metadata fallbacks to reference Jordanian dinar values
- default the mobile configuration currency selection to JOD

## Testing
- php ./vendor/bin/phpunit *(fails: InvalidArgumentException: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68e43116cee4832c8f94a3bcb249858b