### PR TITLE
Fix automatic discount activation on product save

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -61,8 +61,28 @@ class ProductController extends Controller
             return redirect()->back()->withErrors($message);
         }
         $data = $request->all();
-        $data['discount_active'] = $request->boolean('discount_active');
-        if (empty($data['discount_active'])) {
+
+        $discountPrice = $data['discount_price'] ?? null;
+        $price = $data['price'] ?? null;
+
+        $isDiscountActive = $request->boolean('discount_active');
+
+        if (!$isDiscountActive && !is_null($discountPrice)) {
+            $discountPrice = (float) $discountPrice;
+            $price = is_null($price) ? null : (float) $price;
+
+            if ($discountPrice > 0 && (is_null($price) || $discountPrice < $price)) {
+                $isDiscountActive = true;
+            }
+        }
+
+        $data['discount_active'] = $isDiscountActive;
+
+        if ($isDiscountActive && !is_null($discountPrice)) {
+            $data['discount_price'] = (float) $discountPrice;
+        }
+
+        if (!$isDiscountActive) {
             $data['discount_price'] = null;
         }
 
@@ -120,8 +140,28 @@ class ProductController extends Controller
         $product = Product::findOrFail($id);
 
         $data = $request->all();
-        $data['discount_active'] = $request->boolean('discount_active');
-        if (empty($data['discount_active'])) {
+
+        $discountPrice = $data['discount_price'] ?? null;
+        $price = $data['price'] ?? $product->price;
+
+        $isDiscountActive = $request->boolean('discount_active');
+
+        if (!$isDiscountActive && !is_null($discountPrice)) {
+            $discountPrice = (float) $discountPrice;
+            $price = is_null($price) ? null : (float) $price;
+
+            if ($discountPrice > 0 && (is_null($price) || $discountPrice < $price)) {
+                $isDiscountActive = true;
+            }
+        }
+
+        $data['discount_active'] = $isDiscountActive;
+
+        if ($isDiscountActive && !is_null($discountPrice)) {
+            $data['discount_price'] = (float) $discountPrice;
+        }
+
+        if (!$isDiscountActive) {
             $data['discount_price'] = null;
         }
 


### PR DESCRIPTION
## Summary
- automatically enable product discounts when a valid discounted price is supplied during create or update
- normalise stored discount prices to floats while clearing the value when the discount toggle is off

## Testing
- php -l app/Http/Controllers/ProductController.php

------
https://chatgpt.com/codex/tasks/task_e_68e432015510832cacb8b7fbabd7b36f