### PR TITLE
Fix clinic free request route names

### DIFF
--- a/resources/views/partials/dashboard/vertical-nav.blade.php
+++ b/resources/views/partials/dashboard/vertical-nav.blade.php
@@ -105,10 +105,10 @@
                 ->prepend('<i class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" viewBox="0 0 24 24" fill="currentColor"><g><circle cx="12" cy="12" r="8" fill="currentColor"></circle></g></svg></i>')
                 ->link->attr(['class' => activeRoute(route('clinic.schedules.create')) ? 'nav-link active' : 'nav-link']);
 
-            $menu->clinic->add('<span class="item-name">'.__('message.list_form_title',['form' => __('message.free_booking_request')]).'</span>', ['route' => 'clinic.free-requests.index'])
+            $menu->clinic->add('<span class="item-name">'.__('message.list_form_title',['form' => __('message.free_booking_request')]).'</span>', ['route' => 'clinic.free_requests.index'])
                 ->data('role', 'admin')
                 ->prepend('<i class="icon"><svg xmlns="http://www.w3.org/2000/svg" width="10" viewBox="0 0 24 24" fill="currentColor"><g><circle cx="12" cy="12" r="8" fill="currentColor"></circle></g></svg></i>')
-                ->link->attr(['class' => activeRoute(route('clinic.free-requests.index')) || request()->is('clinic/free-requests/*/edit') ? 'nav-link active' : 'nav-link']);
+                ->link->attr(['class' => activeRoute(route('clinic.free_requests.index')) || request()->is('clinic/free-requests/*/edit') ? 'nav-link active' : 'nav-link']);
 
             $menu->clinic->add('<span class="item-name">'.__('message.list_form_title',['form' => __('message.appointment')]).'</span>', ['route' => 'clinic.appointments.index'])
                 ->data('role', 'admin')

--- a/routes/web.php
+++ b/routes/web.php
@@ -179,7 +179,13 @@ Route::group(['middleware' => [ 'auth', 'useractive' ]], function () {
         Route::resource('branches', ClinicBranchController::class)->except(['show']);
         Route::resource('specialists', ClinicSpecialistController::class)->except(['show']);
         Route::resource('schedules', ClinicSpecialistScheduleController::class)->except(['show']);
-        Route::resource('free-requests', ClinicFreeBookingRequestController::class)->only(['index', 'edit', 'update']);
+        Route::resource('free-requests', ClinicFreeBookingRequestController::class)
+            ->only(['index', 'edit', 'update'])
+            ->names([
+                'index' => 'free_requests.index',
+                'edit' => 'free_requests.edit',
+                'update' => 'free_requests.update',
+            ]);
         Route::resource('appointments', ClinicAppointmentController::class)->only(['index', 'edit', 'update']);
     });
     Route::resource('product-orders', ProductOrderController::class)->only(['index', 'show', 'update']);


### PR DESCRIPTION
## Summary
- ensure the clinic free request resource uses underscore-based route names
- update the dashboard navigation to reference the corrected route alias

## Testing
- php artisan route:list --name=clinic.free_requests.index

------
https://chatgpt.com/codex/tasks/task_e_68e439a7e5c4832c8c666e3a0659c6fd