### PR TITLE
Adjust shop layout grid and circular categories

### DIFF
--- a/mobapp/lib/components/product_category_component.dart
+++ b/mobapp/lib/components/product_category_component.dart
@@ -25,15 +25,30 @@ class ProductCategoryComponent extends StatefulWidget {
 class _ProductCategoryComponentState extends State<ProductCategoryComponent> {
   @override
   Widget build(BuildContext context) {
+    final double itemSize = widget.isGrid ? (context.width() - 48) / 2 : 110;
+
     return Container(
-      decoration: boxDecorationWithRoundedCorners(borderRadius: radius(12), backgroundColor: appStore.isDarkMode ? context.cardColor : GreyLightColor),
-      width: widget.isGrid ? (context.width() - 48) / 2 : context.width() * 0.37,
+      width: widget.isGrid ? (context.width() - 48) / 2 : itemSize,
       margin: EdgeInsets.only(top: 4),
-      padding: EdgeInsets.all(2),
       child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          cachedImage(widget.mProductCategoryModel!.productcategoryImage.validate(), fit: BoxFit.contain, height: 90),
-          8.height,
+          Container(
+            height: itemSize,
+            width: itemSize,
+            decoration: boxDecorationWithRoundedCorners(
+              boxShape: BoxShape.circle,
+              backgroundColor: appStore.isDarkMode ? context.cardColor : GreyLightColor,
+            ),
+            padding: EdgeInsets.all(12),
+            child: ClipOval(
+              child: cachedImage(
+                widget.mProductCategoryModel!.productcategoryImage.validate(),
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          12.height,
           Text(
             widget.mProductCategoryModel!.title!.validate(),
             style: primaryTextStyle(size: 14),
@@ -41,7 +56,6 @@ class _ProductCategoryComponentState extends State<ProductCategoryComponent> {
             overflow: TextOverflow.ellipsis,
             textAlign: TextAlign.center,
           ).paddingSymmetric(horizontal: 8),
-          12.height,
         ],
       ),
     ).onTap(() {

--- a/mobapp/lib/screens/product_screen.dart
+++ b/mobapp/lib/screens/product_screen.dart
@@ -123,10 +123,18 @@ class ProductScreenState extends State<ProductScreen> {
   }
 
   Widget mStoreProductList() {
-    return AnimatedWrap(
-      runSpacing: 16,
-      spacing: 16,
-      children: List.generate(mProductList!.length, (index) {
+    return GridView.builder(
+      shrinkWrap: true,
+      physics: NeverScrollableScrollPhysics(),
+      padding: EdgeInsets.symmetric(horizontal: 16),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+        childAspectRatio: 0.66,
+      ),
+      itemCount: mProductList!.length,
+      itemBuilder: (context, index) {
         return ProductComponent(
           mProductModel: mProductList![index],
           onCall: () {
@@ -134,8 +142,8 @@ class ProductScreenState extends State<ProductScreen> {
             setState(() {});
           },
         );
-      }),
-    ).paddingSymmetric(horizontal: 16);
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- display shop products in a fixed two-column grid to ensure two rows of items per screen width
- update product categories to use circular tiles while keeping horizontal scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e43a48c75c832cb17ba6ef3990a96e