### PR TITLE
Fix checkout input decoration label parameter

### DIFF
--- a/mobapp/lib/screens/checkout_screen.dart
+++ b/mobapp/lib/screens/checkout_screen.dart
@@ -150,7 +150,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     controller: _nameController,
                     textFieldType: TextFieldType.NAME,
                     decoration: defaultInputDecoration(context,
-                        hint: languages.lblFullName, labelText: languages.lblFullName),
+                        hint: languages.lblFullName, label: languages.lblFullName),
                     validator: (value) {
                       if (value.validate().isEmpty) {
                         return languages.lblEnterFirstName;
@@ -163,7 +163,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     controller: _phoneController,
                     textFieldType: TextFieldType.PHONE,
                     decoration: defaultInputDecoration(context,
-                        hint: languages.lblPhoneNumber, labelText: languages.lblPhoneNumber),
+                        hint: languages.lblPhoneNumber, label: languages.lblPhoneNumber),
                     validator: (value) {
                       if (value.validate().isEmpty) {
                         return languages.lblEnterPhoneNumber;
@@ -178,7 +178,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     minLines: 3,
                     maxLines: 5,
                     decoration: defaultInputDecoration(context,
-                        hint: languages.lblAddress, labelText: languages.lblAddress),
+                        hint: languages.lblAddress, label: languages.lblAddress),
                     validator: (value) {
                       if (value.validate().isEmpty) {
                         return languages.lblAddress;
@@ -194,7 +194,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     maxLines: 4,
                     decoration: defaultInputDecoration(context,
                         hint: languages.lblOrderNote,
-                        labelText: languages.lblOrderNote),
+                        label: languages.lblOrderNote),
                   ),
                   24.height,
                   Text(languages.lblPaymentMethod, style: boldTextStyle(size: 18)),


### PR DESCRIPTION
## Summary
- update checkout screen text fields to use the correct `label` parameter when building default input decorations

## Testing
- `flutter analyze` *(fails: Flutter SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e43bb8402c832cbc886e65baa15274