### PR TITLE
Add available slot picker to free booking requests

### DIFF
--- a/resources/views/clinic/free_requests/form.blade.php
+++ b/resources/views/clinic/free_requests/form.blade.php
@@ -1,4 +1,41 @@
 <x-app-layout>
+    @php
+        $initialAppointmentTime = old('appointment_time', optional($freeRequest->appointment)->appointment_time ? substr(optional($freeRequest->appointment)->appointment_time, 0, 5) : '');
+    @endphp
+    <style>
+        .slot-button {
+            min-width: 72px;
+            min-height: 48px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 0.5rem;
+            border: 1px solid var(--bs-primary);
+            color: var(--bs-primary);
+            cursor: pointer;
+            transition: all 0.2s ease-in-out;
+            padding: 0.5rem 0.75rem;
+            background-color: #fff;
+        }
+
+        .slot-button:hover {
+            background-color: rgba(13, 110, 253, 0.08);
+        }
+
+        .slot-button.active,
+        .slot-button:focus {
+            background-color: var(--bs-primary);
+            color: #fff;
+        }
+
+        .slot-button.slot-disabled,
+        .slot-button.slot-disabled:hover {
+            border-color: var(--bs-gray-400);
+            color: var(--bs-gray-500);
+            background-color: var(--bs-gray-200);
+            cursor: not-allowed;
+        }
+    </style>
     <div>
         <form method="POST" action="{{ route('clinic.free_requests.update', $freeRequest) }}">
             @csrf
@@ -62,9 +99,15 @@
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label">{{ __('message.start_time') }}</label>
-                                    <input type="time" name="appointment_time" class="form-control" value="{{ old('appointment_time', optional($freeRequest->appointment)->appointment_time ? substr(optional($freeRequest->appointment)->appointment_time,0,5) : '') }}">
+                                    <input type="hidden" name="appointment_time" id="appointment_time_input" value="{{ $initialAppointmentTime }}">
+                                    <div id="available-slots" class="d-flex flex-wrap gap-2">
+                                        <span class="text-muted small">{{ __('Select a specialist and date to view available slots.') }}</span>
+                                    </div>
+                                    <div class="mt-2">
+                                        <span class="small text-muted">{{ __('Selected time:') }} <span id="selected-slot-label" class="fw-semibold">{{ $initialAppointmentTime ?: '—' }}</span></span>
+                                    </div>
                                     @error('appointment_time')
-                                        <small class="text-danger">{{ $message }}</small>
+                                        <small class="text-danger d-block mt-1">{{ $message }}</small>
                                     @enderror
                                 </div>
                             </div>
@@ -85,3 +128,131 @@
         </form>
     </div>
 </x-app-layout>
+
+@push('scripts')
+    <script>
+        (function () {
+            const dateInput = document.querySelector('input[name="appointment_date"]');
+            const specialistSelect = document.querySelector('select[name="specialist_id"]');
+            const slotsContainer = document.getElementById('available-slots');
+            const selectedTimeInput = document.getElementById('appointment_time_input');
+            const selectedTimeLabel = document.getElementById('selected-slot-label');
+            const fetchUrl = "{{ route('clinic.free_requests.available_slots') }}";
+
+            const texts = {
+                selectSpecialistAndDate: "{{ __('Select a specialist and date to view available slots.') }}",
+                noSlots: "{{ __('No slots available for the selected date.') }}",
+                loading: "{{ __('Loading available slots...') }}",
+            };
+
+            const setSelectedTime = (value) => {
+                selectedTimeInput.value = value || '';
+                if (selectedTimeLabel) {
+                    selectedTimeLabel.textContent = value || '—';
+                }
+            };
+
+            const clearSlots = (message) => {
+                slotsContainer.innerHTML = '';
+                const span = document.createElement('span');
+                span.className = 'text-muted small';
+                span.textContent = message;
+                slotsContainer.appendChild(span);
+            };
+
+            const updateActiveState = () => {
+                const buttons = slotsContainer.querySelectorAll('.slot-button');
+                buttons.forEach((button) => {
+                    if (button.dataset.time === selectedTimeInput.value) {
+                        button.classList.add('active');
+                    } else {
+                        button.classList.remove('active');
+                    }
+                });
+            };
+
+            const renderSlots = (slots) => {
+                slotsContainer.innerHTML = '';
+
+                if (!slots.length) {
+                    clearSlots(texts.noSlots);
+                    return;
+                }
+
+                slots.forEach((slot) => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'slot-button' + (slot.is_available ? '' : ' slot-disabled');
+                    button.textContent = slot.time;
+                    button.dataset.time = slot.time;
+
+                    if (!slot.is_available) {
+                        button.disabled = true;
+                    }
+
+                    button.addEventListener('click', () => {
+                        if (button.disabled) {
+                            return;
+                        }
+                        setSelectedTime(slot.time);
+                        updateActiveState();
+                    });
+
+                    slotsContainer.appendChild(button);
+                });
+
+                updateActiveState();
+            };
+
+            const fetchSlots = () => {
+                if (!dateInput.value || !specialistSelect.value) {
+                    setSelectedTime(selectedTimeInput.value);
+                    clearSlots(texts.selectSpecialistAndDate);
+                    return;
+                }
+
+                clearSlots(texts.loading);
+
+                const params = new URLSearchParams({
+                    specialist_id: specialistSelect.value,
+                    date: dateInput.value,
+                });
+
+                fetch(`${fetchUrl}?${params.toString()}`, {
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                })
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error('Request failed');
+                        }
+                        return response.json();
+                    })
+                    .then((data) => {
+                        renderSlots(data.slots || []);
+                    })
+                    .catch(() => {
+                        clearSlots("{{ __('Unable to load slots. Please try again later.') }}");
+                    });
+            };
+
+            if (dateInput && specialistSelect && slotsContainer) {
+                dateInput.addEventListener('change', () => {
+                    setSelectedTime('');
+                    fetchSlots();
+                });
+                specialistSelect.addEventListener('change', () => {
+                    setSelectedTime('');
+                    fetchSlots();
+                });
+
+                if (selectedTimeInput.value) {
+                    setSelectedTime(selectedTimeInput.value);
+                }
+
+                fetchSlots();
+            }
+        })();
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -186,6 +186,8 @@ Route::group(['middleware' => [ 'auth', 'useractive' ]], function () {
                 'edit' => 'free_requests.edit',
                 'update' => 'free_requests.update',
             ]);
+        Route::get('free-requests/available-slots', [ClinicFreeBookingRequestController::class, 'availableSlots'])
+            ->name('free_requests.available_slots');
         Route::resource('appointments', ClinicAppointmentController::class)->only(['index', 'edit', 'update']);
     });
     Route::resource('product-orders', ProductOrderController::class)->only(['index', 'show', 'update']);


### PR DESCRIPTION
## Summary
- add an endpoint that exposes specialist availability for a given date to the clinic free booking module
- enhance the free booking request edit form to show selectable slot tiles tied to the new endpoint
- wire up dynamic JavaScript to fetch slots, handle selections, and persist the chosen appointment time

## Testing
- php artisan test *(fails: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68e43cda1fb0832cb4844cef4a9a5b2a