### PR TITLE
Fix available slot fetch route for clinic free requests

### DIFF
--- a/resources/views/clinic/free_requests/form.blade.php
+++ b/resources/views/clinic/free_requests/form.blade.php
@@ -137,7 +137,7 @@
             const slotsContainer = document.getElementById('available-slots');
             const selectedTimeInput = document.getElementById('appointment_time_input');
             const selectedTimeLabel = document.getElementById('selected-slot-label');
-            const fetchUrl = "{{ route('clinic.free_requests.available_slots') }}";
+            const fetchUrl = "{{ route('clinic.free_requests.available_slots', [], false) }}";
 
             const texts = {
                 selectSpecialistAndDate: "{{ __('Select a specialist and date to view available slots.') }}",
@@ -222,17 +222,19 @@
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                     },
+                    credentials: 'same-origin',
                 })
                     .then((response) => {
                         if (!response.ok) {
-                            throw new Error('Request failed');
+                            throw new Error(`Request failed with status ${response.status}`);
                         }
                         return response.json();
                     })
                     .then((data) => {
                         renderSlots(data.slots || []);
                     })
-                    .catch(() => {
+                    .catch((error) => {
+                        console.error('Failed to load available slots:', error);
                         clearSlots("{{ __('Unable to load slots. Please try again later.') }}");
                     });
             };


### PR DESCRIPTION
## Summary
- use a relative URL when requesting available slots from the clinic free request form
- harden the fetch call with same-origin credentials and clearer error logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43edabb1c832c97fe174ae197ab19