### PR TITLE
Fix free request slot fetch URL

### DIFF
--- a/resources/views/clinic/free_requests/form.blade.php
+++ b/resources/views/clinic/free_requests/form.blade.php
@@ -137,7 +137,7 @@
             const slotsContainer = document.getElementById('available-slots');
             const selectedTimeInput = document.getElementById('appointment_time_input');
             const selectedTimeLabel = document.getElementById('selected-slot-label');
-            const fetchUrl = "{{ route('clinic.free_requests.available_slots', [], false) }}";
+            const fetchUrl = "{{ route('clinic.free_requests.available_slots') }}";
 
             const texts = {
                 selectSpecialistAndDate: "{{ __('Select a specialist and date to view available slots.') }}",


### PR DESCRIPTION
## Summary
- ensure the available slots fetch request uses an absolute URL so it resolves correctly from the edit page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e440975484832cb5597a54a16ca060