### PR TITLE
Fix localization fallback for missing server keys

### DIFF
--- a/mobapp/lib/languageConfiguration/LanguageDataConstant.dart
+++ b/mobapp/lib/languageConfiguration/LanguageDataConstant.dart
@@ -116,19 +116,23 @@ List<Locale> getSupportedLocales() {
 String getContentValueFromKey(int keywordId) {
   String defaultKeyValue = defaultKeyNotFoundValue;
   bool isFoundKey = false;
-  if (selectedServerLanguageData != null) {
+
+  if (selectedServerLanguageData != null &&
+      selectedServerLanguageData!.contentData != null) {
     for (int index = 0;
-    index < selectedServerLanguageData!.contentData!.length;
-    index++) {
+        index < selectedServerLanguageData!.contentData!.length;
+        index++) {
       if (selectedServerLanguageData!.contentData![index].keywordId ==
           keywordId) {
         defaultKeyValue =
-        selectedServerLanguageData!.contentData![index].keywordValue!;
+            selectedServerLanguageData!.contentData![index].keywordValue!;
         isFoundKey = true;
         break;
       }
     }
-  } else {
+  }
+
+  if (!isFoundKey) {
     for (int index = 0; index < defaultLanguageDataKeys.length; index++) {
       if (defaultLanguageDataKeys[index].keywordId == keywordId) {
         defaultKeyValue = defaultLanguageDataKeys[index].keywordValue!;
@@ -137,6 +141,7 @@ String getContentValueFromKey(int keywordId) {
       }
     }
   }
+
   if (!isFoundKey) {
     defaultKeyValue = defaultKeyValue + "($keywordId)";
   }


### PR DESCRIPTION
## Summary
- update language lookup to fall back to bundled defaults when server language data is missing keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e441a8cea8832c83f03b93f72309be