### PR TITLE
Normalize free request schedule weekday matching

### DIFF
--- a/app/Http/Controllers/ClinicFreeBookingRequestController.php
+++ b/app/Http/Controllers/ClinicFreeBookingRequestController.php
@@ -145,8 +145,15 @@ class ClinicFreeBookingRequestController extends Controller
         $specialist = Specialist::with('schedules')->findOrFail($request->specialist_id);
         $date = Carbon::parse($request->date);
 
+        $weekStart = Carbon::create()->startOfWeek();
+
         $schedules = $specialist->schedules
-            ->where('day_of_week', $date->dayOfWeek)
+            ->filter(function ($schedule) use ($date, $weekStart) {
+                $storedDay = (int) $schedule->day_of_week;
+                $normalizedDay = $weekStart->copy()->addDays($storedDay)->dayOfWeek;
+
+                return $normalizedDay === $date->dayOfWeek;
+            })
             ->sortBy('start_time');
 
         $slots = [];

--- a/resources/views/clinic/free_requests/form.blade.php
+++ b/resources/views/clinic/free_requests/form.blade.php
@@ -137,7 +137,7 @@
             const slotsContainer = document.getElementById('available-slots');
             const selectedTimeInput = document.getElementById('appointment_time_input');
             const selectedTimeLabel = document.getElementById('selected-slot-label');
-            const fetchUrl = "{{ route('clinic.free_requests.available_slots', [], false) }}";
+            const fetchUrl = "{{ route('clinic.free_requests.available_slots') }}";
 
             const texts = {
                 selectSpecialistAndDate: "{{ __('Select a specialist and date to view available slots.') }}",


### PR DESCRIPTION
## Summary
- normalize stored specialist schedule weekdays against the selected date so matching slots appear correctly on the free request form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e440975484832cb5597a54a16ca060