### PR TITLE
Fix cart info chips overflow

### DIFF
--- a/mobapp/lib/screens/cart_screen.dart
+++ b/mobapp/lib/screens/cart_screen.dart
@@ -214,14 +214,15 @@ class _CartItemTile extends StatelessWidget {
                   Text(category, style: secondaryTextStyle(size: 12))
                       .paddingTop(4),
                 12.height,
-                Row(
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
                   children: [
                     _InfoChip(
                       icon: Icons.shopping_bag_outlined,
                       label:
                           '${languages.lblQuantity}: ${item.quantity.validate()}',
                     ),
-                    12.width,
                     _InfoChip(
                       icon: Icons.attach_money,
                       label:


### PR DESCRIPTION
## Summary
- prevent the cart item info chips from overflowing by wrapping them when space is constrained

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e49b18839c832c82570c5a96300f5b