### PR TITLE
Ensure manual appointments follow specialist schedules

### DIFF
--- a/resources/lang/ar/message.php
+++ b/resources/lang/ar/message.php
@@ -92,6 +92,8 @@ return [
     'loading' => 'جاري التحميل...',
     'no_slots_available' => 'لا توجد مواعيد متاحة لليوم المختار.',
     'error_fetching_slots' => 'تعذر تحميل المواعيد المتاحة.',
+    'no_schedule_for_day' => 'لا توجد ساعات عمل مسجلة لهذا اليوم.',
+    'working_hours_for_day' => 'ساعات العمل: :range',
     'manual_branch_required' => 'يرجى اختيار الفرع قبل اختيار المتخصص.',
     'full_name' => 'الاسم الكامل',
     'confirm_password' => 'تأكيد كلمة المرور',

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -155,6 +155,8 @@ return [
     'loading' => 'Loading...',
     'no_slots_available' => 'No slots available for the selected day.',
     'error_fetching_slots' => 'Unable to load available slots.',
+    'no_schedule_for_day' => 'No working hours have been configured for the selected day.',
+    'working_hours_for_day' => 'Working hours: :range',
     'manual_branch_required' => 'Please select a branch before choosing the specialist.',
     'full_name' => 'Full name',
     'confirm_password' => 'Confirm password',

--- a/resources/views/partials/dashboard/_dynamic_script.blade.php
+++ b/resources/views/partials/dashboard/_dynamic_script.blade.php
@@ -3,8 +3,24 @@
     'use strict';
     
     $(document).ready(function() {
-        $('.select2js').select2({
-            width: '100%',
+        $('.select2js').each(function() {
+            const $select = $(this);
+            const options = { width: '100%' };
+            const parentSelector = $select.data('dropdownParent');
+
+            if (parentSelector) {
+                const $parent = $(parentSelector);
+                if ($parent.length) {
+                    options.dropdownParent = $parent;
+                }
+            } else {
+                const $modalParent = $select.closest('.modal');
+                if ($modalParent.length) {
+                    options.dropdownParent = $modalParent;
+                }
+            }
+
+            $select.select2(options);
         });
         $.ajaxSetup({
             headers: {


### PR DESCRIPTION
## Summary
- normalise specialist schedules by weekday when loading manual appointment slots and skip past times on the current day
- return slot metadata (totals and working ranges) so the modal can show accurate working hours while listing only available options
- add Arabic and English translations for the new scheduling helper messages

## Testing
- php artisan test *(fails: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a2a12c58832cb75d3f10f0ad0748