### PR TITLE
Improve manual appointment slot handling

### DIFF
--- a/resources/views/clinic/appointments/index.blade.php
+++ b/resources/views/clinic/appointments/index.blade.php
@@ -235,16 +235,39 @@
             function toggleManualSections(type) {
                 const freeSections = document.querySelectorAll('.manual-free-section');
                 const regularSections = document.querySelectorAll('.manual-regular-section');
+                const manualUser = document.getElementById('manual-user');
+                const manualName = document.getElementById('manual-name');
+                const manualPhone = document.getElementById('manual-phone');
+                const manualBranch = document.getElementById('manual-branch');
 
                 freeSections.forEach(section => section.classList.toggle('d-none', type !== 'manual_free'));
                 regularSections.forEach(section => section.classList.toggle('d-none', type === 'manual_free'));
 
                 if (type === 'manual_free') {
-                    document.getElementById('manual-user').value = '';
+                    if (manualUser) {
+                        $(manualUser).val('').prop('disabled', true).trigger('change');
+                    }
+                    if (manualName) {
+                        manualName.setAttribute('required', 'required');
+                    }
+                    if (manualPhone) {
+                        manualPhone.setAttribute('required', 'required');
+                    }
                 } else {
-                    document.getElementById('manual-name').value = '';
-                    document.getElementById('manual-phone').value = '';
-                    document.getElementById('manual-branch').value = '';
+                    if (manualUser) {
+                        $(manualUser).prop('disabled', false).trigger('change');
+                    }
+                    if (manualName) {
+                        manualName.value = '';
+                        manualName.removeAttribute('required');
+                    }
+                    if (manualPhone) {
+                        manualPhone.value = '';
+                        manualPhone.removeAttribute('required');
+                    }
+                    if (manualBranch) {
+                        manualBranch.value = '';
+                    }
                 }
             }
 
@@ -350,22 +373,22 @@
                         const availableSlots = slots.filter(function(slot) {
                             return slot && slot.available;
                         });
-                        const select = document.getElementById('manual-time');
-                        select.innerHTML = '';
+                        const workingRanges = response && response.meta && Array.isArray(response.meta.working_ranges)
+                            ? response.meta.working_ranges
+                            : [];
+                        const helperText = formatWorkingRanges(workingRanges);
 
-                        if (!availableSlots.length) {
-                            resetTimeSelect(slots.length ? "{{ __('message.no_slots_available') }}" : "{{ __('message.error_fetching_slots') }}");
+                        if (!slots.length) {
+                            resetTimeSelect(messages.noSchedule, helperText);
                             return;
                         }
 
-                        select.innerHTML = `<option value="">{{ __('message.select_name', ['select' => __('message.start_time')]) }}</option>`;
-                        availableSlots.forEach(function(slot) {
-                            const option = document.createElement('option');
-                            option.value = slot.time;
-                            option.textContent = slot.time;
-                            select.appendChild(option);
-                        });
-                        document.getElementById('manual-time-helper').textContent = '';
+                        if (!availableSlots.length) {
+                            resetTimeSelect(messages.noSlots, helperText);
+                            return;
+                        }
+
+                        setTimeOptions(availableSlots, helperText);
                     })
                     .fail(function() {
                         setTimeMessage(messages.error);


### PR DESCRIPTION
## Summary
- disable the manual appointment user selector when creating free appointments and require entering the guest name and phone number
- reuse the slot helper utilities to show working hours and clearer messages when fetching available times
- ensure the time dropdown is populated only when slots exist and explain when no schedule or slots are available

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4a6d960b0832ca65a503e5e02a4b9