### PR TITLE
Ensure pushed scripts render in dashboard layouts

### DIFF
--- a/resources/views/layouts/dashboard/guest.blade.php
+++ b/resources/views/layouts/dashboard/guest.blade.php
@@ -31,5 +31,6 @@
             {{ $slot }}
         </div>
          @include('partials.dashboard._scripts')
+         @stack('scripts')
     </body>
 </html>

--- a/resources/views/layouts/dashboard/simple.blade.php
+++ b/resources/views/layouts/dashboard/simple.blade.php
@@ -19,5 +19,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </head>
 <body class data-bs-spy="scroll" data-bs-target="#elements-section" data-bs-offset="0" tabindex="0" >
     @include('partials.dashboard._body7')
+    @stack('scripts')
 </body>
 </html>

--- a/resources/views/partials/dashboard/_body.blade.php
+++ b/resources/views/partials/dashboard/_body.blade.php
@@ -24,6 +24,7 @@
 @include('partials.dashboard._scripts')
 @include('partials.dashboard._dynamic_script')
 @include('partials.dashboard._app_toast')
+@stack('scripts')
 <div class="modal fade" id="formModal">
 <div class="modal-dialog">
     <div class="modal-content">

--- a/resources/views/partials/dashboard/_scripts.blade.php
+++ b/resources/views/partials/dashboard/_scripts.blade.php
@@ -62,8 +62,6 @@
 @endif
 
 
-@stack('scripts')
-
 <script src="{{asset('js/plugins/prism.mini.js')}}"></script>
 
 <!-- Custom JavaScript -->


### PR DESCRIPTION
## Summary
- move the `@stack('scripts')` output out of the shared scripts partial
- ensure each dashboard layout prints the scripts stack after the base assets so pushed scripts execute

## Testing
- not run (database-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68e4c3463c10832c9070fcb527a51be5