### PR TITLE
Ensure script stacks render in dashboard layout

### DIFF
--- a/resources/views/layouts/dashboard/dashboard.blade.php
+++ b/resources/views/layouts/dashboard/dashboard.blade.php
@@ -12,6 +12,7 @@
 </head>
 <body class="" >
 @include('partials.dashboard._body')
+@stack('scripts')
 </body>
 
 </html>

--- a/resources/views/partials/dashboard/_body.blade.php
+++ b/resources/views/partials/dashboard/_body.blade.php
@@ -24,7 +24,6 @@
 @include('partials.dashboard._scripts')
 @include('partials.dashboard._dynamic_script')
 @include('partials.dashboard._app_toast')
-@stack('scripts')
 <div class="modal fade" id="formModal">
 <div class="modal-dialog">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- ensure the dashboard layout renders the `scripts` stack so page-specific pushes execute
- keep the shared body partial focused on structural includes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c5e27658832c974d250d71628a04