### PR TITLE
Render pushed scripts through dashboard scripts partial

### DIFF
--- a/resources/views/layouts/dashboard/guest.blade.php
+++ b/resources/views/layouts/dashboard/guest.blade.php
@@ -31,6 +31,5 @@
             {{ $slot }}
         </div>
          @include('partials.dashboard._scripts')
-         @stack('scripts')
     </body>
 </html>

--- a/resources/views/layouts/dashboard/simple.blade.php
+++ b/resources/views/layouts/dashboard/simple.blade.php
@@ -19,6 +19,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 </head>
 <body class data-bs-spy="scroll" data-bs-target="#elements-section" data-bs-offset="0" tabindex="0" >
     @include('partials.dashboard._body7')
-    @stack('scripts')
+    @include('partials.dashboard._scripts')
 </body>
 </html>

--- a/resources/views/partials/dashboard/_body.blade.php
+++ b/resources/views/partials/dashboard/_body.blade.php
@@ -24,7 +24,6 @@
 @include('partials.dashboard._scripts')
 @include('partials.dashboard._dynamic_script')
 @include('partials.dashboard._app_toast')
-@stack('scripts')
 <div class="modal fade" id="formModal">
 <div class="modal-dialog">
     <div class="modal-content">

--- a/resources/views/partials/dashboard/_scripts.blade.php
+++ b/resources/views/partials/dashboard/_scripts.blade.php
@@ -67,3 +67,4 @@
 <!-- Custom JavaScript -->
 <script src="{{asset('js/hope-ui.js') }}"></script>
 <script src="{{asset('js/modelview.js')}}"></script>
+@stack('scripts')


### PR DESCRIPTION
## Summary
- add the `scripts` stack output to the shared dashboard scripts partial so pushed snippets render after core assets
- update the dashboard, guest, and simple layouts to rely on the partial for loading base assets and stacked scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c5e27658832c974d250d71628a04