### PR TITLE
Add comprehensive meal plan support for diets

### DIFF
--- a/app/Support/MealPlan.php
+++ b/app/Support/MealPlan.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Support;
+
+use InvalidArgumentException;
+
+class MealPlan
+{
+    public static function normalizePlan($plan, bool $strict = false, bool $preserveKeys = false): array
+    {
+        if (!is_array($plan)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($plan as $dayIndex => $dayMeals) {
+            $dayKey = (int) $dayIndex;
+
+            if (!array_key_exists($dayKey, $normalized)) {
+                $normalized[$dayKey] = [];
+            }
+
+            if (!is_array($dayMeals)) {
+                if ($strict && $dayMeals !== null && $dayMeals !== '') {
+                    throw new InvalidArgumentException('Invalid meal plan structure.');
+                }
+
+                continue;
+            }
+
+            foreach ($dayMeals as $mealIndex => $meal) {
+                $mealKey = (int) $mealIndex;
+                $normalized[$dayKey][$mealKey] = self::normalizeMeal($meal, $strict);
+            }
+
+            ksort($normalized[$dayKey]);
+        }
+
+        ksort($normalized);
+
+        if ($preserveKeys) {
+            return $normalized;
+        }
+
+        return array_values(array_map(function ($dayMeals) {
+            if (!is_array($dayMeals)) {
+                return [];
+            }
+
+            return array_values(array_map(function ($mealEntries) {
+                return array_values(is_array($mealEntries) ? $mealEntries : []);
+            }, $dayMeals));
+        }, $normalized));
+    }
+
+    public static function normalizeMeal($meal, bool $strict = false): array
+    {
+        $normalized = [];
+        $seen = [];
+
+        if (is_array($meal)) {
+            foreach ($meal as $entry) {
+                $normalizedEntry = self::normalizeEntry($entry, $strict, $seen);
+
+                if ($normalizedEntry !== null) {
+                    $normalized[] = $normalizedEntry;
+                }
+            }
+
+            return $normalized;
+        }
+
+        if ($meal === null || $meal === '') {
+            return [];
+        }
+
+        $normalizedEntry = self::normalizeEntry($meal, $strict, $seen);
+
+        return $normalizedEntry !== null ? [$normalizedEntry] : [];
+    }
+
+    public static function normalizeEntry($value, bool $strict = false, array &$seen = []): ?array
+    {
+        if (is_object($value)) {
+            $value = (array) $value;
+        }
+
+        if (is_array($value)) {
+            $id = $value['id'] ?? $value['ingredient_id'] ?? $value['ingredient'] ?? null;
+            $quantity = $value['quantity'] ?? $value['qty'] ?? $value['amount'] ?? 1;
+
+            if ($id === null) {
+                if ($strict) {
+                    throw new InvalidArgumentException('Invalid meal ingredient entry.');
+                }
+
+                return null;
+            }
+
+            $id = (int) $id;
+            $quantity = self::sanitizeQuantity($quantity, $strict);
+
+            if ($id <= 0 || $quantity === null || in_array($id, $seen, true)) {
+                return null;
+            }
+
+            $seen[] = $id;
+
+            return [
+                'id' => $id,
+                'quantity' => $quantity,
+            ];
+        }
+
+        if (!is_numeric($value)) {
+            if ($strict) {
+                throw new InvalidArgumentException('Invalid meal ingredient value.');
+            }
+
+            return null;
+        }
+
+        $id = (int) $value;
+
+        if ($id <= 0 || in_array($id, $seen, true)) {
+            return null;
+        }
+
+        $seen[] = $id;
+
+        return [
+            'id' => $id,
+            'quantity' => 1.0,
+        ];
+    }
+
+    public static function mergeNormalizedPlans(array $base, array $override): array
+    {
+        foreach ($override as $dayIndex => $dayMeals) {
+            if (!isset($base[$dayIndex]) || !is_array($base[$dayIndex])) {
+                $base[$dayIndex] = [];
+            }
+
+            foreach ($dayMeals as $mealIndex => $entries) {
+                $base[$dayIndex][$mealIndex] = is_array($entries)
+                    ? array_values($entries)
+                    : [];
+            }
+
+            ksort($base[$dayIndex]);
+        }
+
+        ksort($base);
+
+        return self::reindexPlan($base);
+    }
+
+    public static function reindexPlan(array $plan): array
+    {
+        ksort($plan);
+
+        return array_values(array_map(function ($dayMeals) {
+            if (!is_array($dayMeals)) {
+                return [];
+            }
+
+            ksort($dayMeals);
+
+            return array_values(array_map(function ($mealEntries) {
+                if (!is_array($mealEntries)) {
+                    return [];
+                }
+
+                return array_values(array_map(function ($entry) {
+                    return is_array($entry) ? $entry : [];
+                }, $mealEntries));
+            }, $dayMeals));
+        }, $plan));
+    }
+
+    protected static function sanitizeQuantity($value, bool $strict): ?float
+    {
+        if ($value === null || $value === '') {
+            if ($strict) {
+                throw new InvalidArgumentException('Invalid meal ingredient quantity.');
+            }
+
+            return null;
+        }
+
+        if (is_string($value)) {
+            $value = str_replace(',', '.', $value);
+        }
+
+        if (!is_numeric($value)) {
+            if ($strict) {
+                throw new InvalidArgumentException('Invalid meal ingredient quantity.');
+            }
+
+            return null;
+        }
+
+        $quantity = (float) $value;
+
+        if ($quantity <= 0) {
+            if ($strict) {
+                throw new InvalidArgumentException('Invalid meal ingredient quantity.');
+            }
+
+            return null;
+        }
+
+        return round($quantity, 2);
+    }
+}

--- a/app/Traits/BuildsMealPlanDetails.php
+++ b/app/Traits/BuildsMealPlanDetails.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\Ingredient;
+
+trait BuildsMealPlanDetails
+{
+    protected function buildMealPlanDetails(array $plan): array
+    {
+        if (empty($plan)) {
+            return [];
+        }
+
+        $ingredientIds = [];
+
+        foreach ($plan as $dayMeals) {
+            if (!is_array($dayMeals)) {
+                continue;
+            }
+
+            foreach ($dayMeals as $mealEntries) {
+                if (!is_array($mealEntries)) {
+                    continue;
+                }
+
+                foreach ($mealEntries as $entry) {
+                    if (!is_array($entry)) {
+                        continue;
+                    }
+
+                    $id = (int) ($entry['id'] ?? 0);
+
+                    if ($id > 0) {
+                        $ingredientIds[] = $id;
+                    }
+                }
+            }
+        }
+
+        $ingredientIds = array_values(array_unique($ingredientIds));
+
+        if (empty($ingredientIds)) {
+            return [];
+        }
+
+        $ingredients = Ingredient::whereIn('id', $ingredientIds)->get()->keyBy('id');
+
+        $days = [];
+
+        foreach ($plan as $dayIndex => $dayMeals) {
+            $meals = [];
+            $dayTotals = [
+                'protein' => 0.0,
+                'carbs' => 0.0,
+                'fat' => 0.0,
+                'calories' => 0.0,
+            ];
+
+            if (!is_array($dayMeals)) {
+                $days[] = [
+                    'day_number' => (int) $dayIndex + 1,
+                    'meals' => [],
+                    'totals' => $this->formatTotals($dayTotals),
+                ];
+
+                continue;
+            }
+
+            foreach ($dayMeals as $mealIndex => $mealEntries) {
+                $mealDetails = [];
+                $mealTotals = [
+                    'protein' => 0.0,
+                    'carbs' => 0.0,
+                    'fat' => 0.0,
+                    'calories' => 0.0,
+                ];
+
+                if (is_array($mealEntries)) {
+                    foreach ($mealEntries as $entry) {
+                        if (!is_array($entry)) {
+                            continue;
+                        }
+
+                        $ingredientId = (int) ($entry['id'] ?? 0);
+
+                        if ($ingredientId <= 0) {
+                            continue;
+                        }
+
+                        $ingredient = $ingredients->get($ingredientId);
+
+                        if (!$ingredient) {
+                            continue;
+                        }
+
+                        $quantity = isset($entry['quantity']) ? (float) $entry['quantity'] : 1.0;
+
+                        if ($quantity <= 0) {
+                            continue;
+                        }
+
+                        $baseProtein = (float) $ingredient->protein;
+                        $baseCarbs = (float) $ingredient->carbs;
+                        $baseFat = (float) $ingredient->fat;
+                        $baseCalories = ($baseProtein * 4) + ($baseCarbs * 4) + ($baseFat * 9);
+
+                        $protein = round($baseProtein * $quantity, 2);
+                        $carbs = round($baseCarbs * $quantity, 2);
+                        $fat = round($baseFat * $quantity, 2);
+                        $calories = round($baseCalories * $quantity, 2);
+
+                        $mealTotals['protein'] += $protein;
+                        $mealTotals['carbs'] += $carbs;
+                        $mealTotals['fat'] += $fat;
+                        $mealTotals['calories'] += $calories;
+
+                        $mealDetails[] = [
+                            'id' => $ingredientId,
+                            'title' => $ingredient->title,
+                            'quantity' => round($quantity, 2),
+                            'protein' => $protein,
+                            'carbs' => $carbs,
+                            'fat' => $fat,
+                            'calories' => $calories,
+                            'image' => getSingleMedia($ingredient, 'ingredient_image', null),
+                            'description' => $ingredient->description,
+                        ];
+                    }
+                }
+
+                $dayTotals['protein'] += $mealTotals['protein'];
+                $dayTotals['carbs'] += $mealTotals['carbs'];
+                $dayTotals['fat'] += $mealTotals['fat'];
+                $dayTotals['calories'] += $mealTotals['calories'];
+
+                $meals[] = [
+                    'meal_number' => (int) $mealIndex + 1,
+                    'ingredients' => $mealDetails,
+                    'totals' => $this->formatTotals($mealTotals),
+                ];
+            }
+
+            $days[] = [
+                'day_number' => (int) $dayIndex + 1,
+                'meals' => $meals,
+                'totals' => $this->formatTotals($dayTotals),
+            ];
+        }
+
+        return $days;
+    }
+
+    protected function formatTotals(array $totals): array
+    {
+        return [
+            'protein' => round($totals['protein'] ?? 0, 2),
+            'carbs' => round($totals['carbs'] ?? 0, 2),
+            'fat' => round($totals['fat'] ?? 0, 2),
+            'calories' => round($totals['calories'] ?? 0, 2),
+        ];
+    }
+}

--- a/mobapp/lib/components/meal_plan_view.dart
+++ b/mobapp/lib/components/meal_plan_view.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:nb_utils/nb_utils.dart';
+
+import '../main.dart';
+import '../models/diet_response.dart';
+import '../extensions/widgets.dart';
+
+class MealPlanView extends StatelessWidget {
+  final List<MealPlanDay> days;
+  final EdgeInsetsGeometry? padding;
+
+  const MealPlanView({Key? key, required this.days, this.padding}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (days.isEmpty) {
+      final noDataText = appStore.selectedLanguageCode == 'ar'
+          ? 'لا توجد خطة وجبات متاحة.'
+          : 'No meal plan available yet.';
+
+      return Text(noDataText, style: secondaryTextStyle());
+    }
+
+    Widget content = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: days.map((day) => _buildDayCard(context, day)).toList(),
+    );
+
+    if (padding != null) {
+      content = content.padding(padding!);
+    }
+
+    return content;
+  }
+
+  Widget _buildDayCard(BuildContext context, MealPlanDay day) {
+    final dayTitle = '${languages.lblDay} ${day.dayNumber}';
+
+    return Container(
+      margin: EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: context.cardColor,
+        borderRadius: radius(16),
+        boxShadow: defaultBoxShadow(spreadRadius: 0, blurRadius: 8),
+      ),
+      padding: EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(dayTitle, style: boldTextStyle(size: 16)),
+          12.height,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: day.meals.map((meal) => _buildMealSection(context, meal)).toList(),
+          ),
+          12.height,
+          _buildTotalsRow(context, day.totals),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMealSection(BuildContext context, MealPlanMeal meal) {
+    final mealTitle = appStore.selectedLanguageCode == 'ar'
+        ? 'الوجبة ${meal.mealNumber}'
+        : 'Meal ${meal.mealNumber}';
+
+    return Container(
+      margin: EdgeInsets.only(bottom: 16),
+      decoration: BoxDecoration(
+        color: context.scaffoldBackgroundColor,
+        borderRadius: radius(12),
+      ),
+      padding: EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(mealTitle, style: boldTextStyle()),
+          12.height,
+          Column(
+            children: meal.ingredients.map((ingredient) => _buildIngredientTile(context, ingredient)).toList(),
+          ),
+          12.height,
+          _buildTotalsRow(context, meal.totals, showLabel: true),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildIngredientTile(BuildContext context, MealPlanIngredientDetail ingredient) {
+    final hasImage = ingredient.image.validate().isNotEmpty;
+    final quantityLabel = appStore.selectedLanguageCode == 'ar' ? 'الكمية' : 'Quantity';
+    final gramsLabel = appStore.selectedLanguageCode == 'ar' ? 'جرام' : 'g';
+    final macroText = '${languages.lblProtein}: ${_formatDouble(ingredient.protein)} $gramsLabel\n'
+        '${languages.lblCarbs}: ${_formatDouble(ingredient.carbs)} $gramsLabel\n'
+        '${languages.lblFat}: ${_formatDouble(ingredient.fat)} $gramsLabel\n'
+        '${languages.lblCalories}: ${_formatDouble(ingredient.calories)} ${languages.lblKcal}';
+
+    return Container(
+      margin: EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (hasImage)
+            ClipRRect(
+              borderRadius: radius(32),
+              child: cachedImage(
+                ingredient.image.validate(),
+                height: 48,
+                width: 48,
+                fit: BoxFit.cover,
+              ),
+            )
+          else
+            Container(
+              height: 48,
+              width: 48,
+              decoration: BoxDecoration(
+                color: context.dividerColor,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(Icons.restaurant_menu, color: context.iconColor, size: 22),
+            ),
+          12.width,
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(ingredient.title.validate(), style: primaryTextStyle()),
+              4.height,
+              Text('$quantityLabel: ${_formatDouble(ingredient.quantity)}', style: secondaryTextStyle()),
+              4.height,
+              Text(macroText, style: secondaryTextStyle(size: 12)),
+            ],
+          ).expand(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotalsRow(BuildContext context, MealPlanTotals totals, {bool showLabel = false}) {
+    final gramsLabel = appStore.selectedLanguageCode == 'ar' ? 'جرام' : 'g';
+    final label = showLabel
+        ? (appStore.selectedLanguageCode == 'ar' ? 'إجمالي الوجبة' : 'Meal totals')
+        : (appStore.selectedLanguageCode == 'ar' ? 'إجمالي اليوم' : 'Day totals');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: boldTextStyle()),
+        8.height,
+        Wrap(
+          spacing: 12,
+          runSpacing: 8,
+          children: [
+            _buildTotalChip(context, languages.lblProtein, '${_formatDouble(totals.protein)} $gramsLabel'),
+            _buildTotalChip(context, languages.lblCarbs, '${_formatDouble(totals.carbs)} $gramsLabel'),
+            _buildTotalChip(context, languages.lblFat, '${_formatDouble(totals.fat)} $gramsLabel'),
+            _buildTotalChip(context, languages.lblCalories, '${_formatDouble(totals.calories)} ${languages.lblKcal}'),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTotalChip(BuildContext context, String label, String value) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: context.dividerColor.withOpacity(0.2),
+        borderRadius: radius(20),
+      ),
+      child: RichText(
+        text: TextSpan(
+          style: secondaryTextStyle(),
+          children: [
+            TextSpan(text: '$label: ', style: boldTextStyle(size: 12)),
+            TextSpan(text: value, style: secondaryTextStyle(size: 12)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDouble(double value) {
+    if (value % 1 == 0) {
+      return value.toStringAsFixed(0);
+    }
+
+    return value.toStringAsFixed(2);
+  }
+}

--- a/mobapp/lib/models/dashboard_response.dart
+++ b/mobapp/lib/models/dashboard_response.dart
@@ -2,6 +2,7 @@ import '../models/workout_detail_response.dart';
 import '../utils/json_utils.dart';
 
 import 'body_part_response.dart';
+import 'diet_response.dart';
 import 'equipment_response.dart';
 import 'exercise_response.dart';
 import 'level_response.dart';
@@ -143,7 +144,10 @@ class Diet {
   String? totalTime;
   String? isFeatured;
   String? status;
-  String? ingredients;
+  List<List<MealIngredientEntry>>? plan;
+  List<List<MealIngredientEntry>>? customPlan;
+  List<MealPlanDay>? mealPlan;
+  bool? hasCustomPlan;
   String? description;
   String? dietImage;
   int? isPremium;
@@ -164,7 +168,10 @@ class Diet {
       this.totalTime,
       this.isFeatured,
       this.status,
-      this.ingredients,
+      this.plan,
+      this.customPlan,
+      this.mealPlan,
+      this.hasCustomPlan,
       this.description,
       this.dietImage,
       this.isPremium,
@@ -185,7 +192,10 @@ class Diet {
     totalTime = parseStringFromJson(json['total_time']);
     isFeatured = parseStringFromJson(json['is_featured']);
     status = parseStringFromJson(json['status']);
-    ingredients = parseStringFromJson(json['ingredients']);
+    plan = parseMealEntryMatrix(json['ingredients']);
+    customPlan = parseMealEntryMatrix(json['custom_plan']);
+    hasCustomPlan = json['has_custom_plan'] == true;
+    mealPlan = parseMealPlanDays(json['meal_plan']);
     description = parseStringFromJson(json['description']);
     dietImage = parseStringFromJson(json['diet_image']);
     isPremium = json['is_premium'];
@@ -208,7 +218,22 @@ class Diet {
     data['total_time'] = this.totalTime;
     data['is_featured'] = this.isFeatured;
     data['status'] = this.status;
-    data['ingredients'] = this.ingredients;
+    if (this.plan != null) {
+      data['ingredients'] = this
+          .plan!
+          .map((day) => day.map((entry) => entry.toJson()).toList())
+          .toList();
+    }
+    if (this.customPlan != null) {
+      data['custom_plan'] = this
+          .customPlan!
+          .map((day) => day.map((entry) => entry.toJson()).toList())
+          .toList();
+    }
+    if (this.mealPlan != null) {
+      data['meal_plan'] = this.mealPlan!.map((e) => e.toJson()).toList();
+    }
+    data['has_custom_plan'] = this.hasCustomPlan;
     data['description'] = this.description;
     data['diet_image'] = this.dietImage;
     data['is_premium'] = this.isPremium;

--- a/mobapp/lib/models/diet_response.dart
+++ b/mobapp/lib/models/diet_response.dart
@@ -42,7 +42,10 @@ class DietModel {
   String? totalTime;
   String? isFeatured;
   String? status;
-  String? ingredients;
+  List<List<MealIngredientEntry>>? plan;
+  List<List<MealIngredientEntry>>? customPlan;
+  List<MealPlanDay>? mealPlan;
+  bool? hasCustomPlan;
   String? description;
   String? dietImage;
   int? isPremium;
@@ -63,7 +66,10 @@ class DietModel {
         this.totalTime,
         this.isFeatured,
         this.status,
-        this.ingredients,
+        this.plan,
+        this.customPlan,
+        this.mealPlan,
+        this.hasCustomPlan,
         this.description,
         this.dietImage,
         this.isPremium,
@@ -84,7 +90,10 @@ class DietModel {
     totalTime = json['total_time'];
     isFeatured = json['is_featured'];
     status = json['status'];
-    ingredients = json['ingredients'];
+    plan = parseMealEntryMatrix(json['ingredients']);
+    customPlan = parseMealEntryMatrix(json['custom_plan']);
+    hasCustomPlan = json['has_custom_plan'] == true;
+    mealPlan = parseMealPlanDays(json['meal_plan']);
     description = json['description'];
     dietImage = json['diet_image'];
     isPremium = json['is_premium'];
@@ -107,7 +116,22 @@ class DietModel {
     data['total_time'] = this.totalTime;
     data['is_featured'] = this.isFeatured;
     data['status'] = this.status;
-    data['ingredients'] = this.ingredients;
+    if (this.plan != null) {
+      data['ingredients'] = this
+          .plan!
+          .map((day) => day.map((entry) => entry.toJson()).toList())
+          .toList();
+    }
+    if (this.customPlan != null) {
+      data['custom_plan'] = this
+          .customPlan!
+          .map((day) => day.map((entry) => entry.toJson()).toList())
+          .toList();
+    }
+    if (this.mealPlan != null) {
+      data['meal_plan'] = this.mealPlan!.map((e) => e.toJson()).toList();
+    }
+    data['has_custom_plan'] = this.hasCustomPlan;
     data['description'] = this.description;
     data['diet_image'] = this.dietImage;
     data['is_premium'] = this.isPremium;
@@ -117,5 +141,278 @@ class DietModel {
     data['updated_at'] = this.updatedAt;
     data['is_favourite'] = this.isFavourite;
     return data;
+  }
+}
+
+List<List<MealIngredientEntry>>? parseMealEntryMatrix(dynamic value) {
+  if (value is List) {
+    return value.map<List<MealIngredientEntry>>((day) {
+      if (day is List) {
+        return day
+            .map<MealIngredientEntry>((meal) => MealIngredientEntry.fromJson(meal))
+            .where((entry) => entry.id != null && entry.id! > 0)
+            .toList();
+      }
+
+      return <MealIngredientEntry>[];
+    }).toList();
+  }
+
+  return null;
+}
+
+List<MealPlanDay>? parseMealPlanDays(dynamic value) {
+  if (value is List) {
+    return value
+        .map((day) => MealPlanDay.fromJson(_ensureMap(day)))
+        .whereType<MealPlanDay>()
+        .toList();
+  }
+
+  return null;
+}
+
+Map<String, dynamic>? _ensureMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+
+  if (value is Map) {
+    return Map<String, dynamic>.from(value);
+  }
+
+  return null;
+}
+
+double _parseDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+
+  if (value is String) {
+    return double.tryParse(value) ?? 0;
+  }
+
+  return 0;
+}
+
+int _parseInt(dynamic value) {
+  if (value is int) {
+    return value;
+  }
+
+  if (value is num) {
+    return value.toInt();
+  }
+
+  if (value is String) {
+    return int.tryParse(value) ?? 0;
+  }
+
+  return 0;
+}
+
+class MealIngredientEntry {
+  int? id;
+  double quantity;
+
+  MealIngredientEntry({this.id, this.quantity = 1});
+
+  factory MealIngredientEntry.fromJson(dynamic json) {
+    if (json is Map) {
+      final map = _ensureMap(json) ?? {};
+
+      return MealIngredientEntry(
+        id: _parseInt(map['id'] ?? map['ingredient_id'] ?? map['ingredient']),
+        quantity: sanitizeQuantityValue(map['quantity'] ?? map['qty'] ?? map['amount']),
+      );
+    }
+
+    if (json is num || json is String) {
+      return MealIngredientEntry(
+        id: _parseInt(json),
+        quantity: 1,
+      );
+    }
+
+    return MealIngredientEntry(id: null, quantity: 1);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'quantity': quantity,
+    };
+  }
+
+  static double sanitizeQuantityValue(dynamic value) {
+    if (value == null) {
+      return 1;
+    }
+
+    if (value is String) {
+      final normalized = value.replaceAll(',', '.');
+      final parsed = double.tryParse(normalized) ?? 1;
+      return parsed <= 0 ? 1 : parsed;
+    }
+
+    if (value is num) {
+      final parsed = value.toDouble();
+      return parsed <= 0 ? 1 : parsed;
+    }
+
+    return 1;
+  }
+}
+
+class MealPlanTotals {
+  double protein;
+  double carbs;
+  double fat;
+  double calories;
+
+  MealPlanTotals({
+    this.protein = 0,
+    this.carbs = 0,
+    this.fat = 0,
+    this.calories = 0,
+  });
+
+  factory MealPlanTotals.fromJson(Map<String, dynamic>? json) {
+    json ??= {};
+
+    return MealPlanTotals(
+      protein: _parseDouble(json['protein']),
+      carbs: _parseDouble(json['carbs']),
+      fat: _parseDouble(json['fat']),
+      calories: _parseDouble(json['calories']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'protein': protein,
+      'carbs': carbs,
+      'fat': fat,
+      'calories': calories,
+    };
+  }
+}
+
+class MealPlanIngredientDetail {
+  int? id;
+  String? title;
+  double quantity;
+  double protein;
+  double carbs;
+  double fat;
+  double calories;
+  String? image;
+  String? description;
+
+  MealPlanIngredientDetail({
+    this.id,
+    this.title,
+    this.quantity = 1,
+    this.protein = 0,
+    this.carbs = 0,
+    this.fat = 0,
+    this.calories = 0,
+    this.image,
+    this.description,
+  });
+
+  factory MealPlanIngredientDetail.fromJson(Map<String, dynamic>? json) {
+    json ??= {};
+
+    return MealPlanIngredientDetail(
+      id: _parseInt(json['id']),
+      title: json['title']?.toString(),
+      quantity: _parseDouble(json['quantity']),
+      protein: _parseDouble(json['protein']),
+      carbs: _parseDouble(json['carbs']),
+      fat: _parseDouble(json['fat']),
+      calories: _parseDouble(json['calories']),
+      image: json['image']?.toString(),
+      description: json['description']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'quantity': quantity,
+      'protein': protein,
+      'carbs': carbs,
+      'fat': fat,
+      'calories': calories,
+      'image': image,
+      'description': description,
+    };
+  }
+}
+
+class MealPlanMeal {
+  int mealNumber;
+  List<MealPlanIngredientDetail> ingredients;
+  MealPlanTotals totals;
+
+  MealPlanMeal({required this.mealNumber, required this.ingredients, required this.totals});
+
+  factory MealPlanMeal.fromJson(Map<String, dynamic>? json) {
+    json ??= {};
+
+    final ingredientsJson = json['ingredients'] as List? ?? [];
+
+    return MealPlanMeal(
+      mealNumber: _parseInt(json['meal_number']),
+      ingredients: ingredientsJson
+          .map((ingredient) => MealPlanIngredientDetail.fromJson(_ensureMap(ingredient)))
+          .whereType<MealPlanIngredientDetail>()
+          .toList(),
+      totals: MealPlanTotals.fromJson(_ensureMap(json['totals'])),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'meal_number': mealNumber,
+      'ingredients': ingredients.map((e) => e.toJson()).toList(),
+      'totals': totals.toJson(),
+    };
+  }
+}
+
+class MealPlanDay {
+  int dayNumber;
+  List<MealPlanMeal> meals;
+  MealPlanTotals totals;
+
+  MealPlanDay({required this.dayNumber, required this.meals, required this.totals});
+
+  factory MealPlanDay.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return MealPlanDay(dayNumber: 0, meals: [], totals: MealPlanTotals());
+    }
+
+    final mealsJson = json['meals'] as List? ?? [];
+
+    return MealPlanDay(
+      dayNumber: _parseInt(json['day_number']),
+      meals: mealsJson
+          .map((meal) => MealPlanMeal.fromJson(_ensureMap(meal)))
+          .whereType<MealPlanMeal>()
+          .toList(),
+      totals: MealPlanTotals.fromJson(_ensureMap(json['totals'])),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'day_number': dayNumber,
+      'meals': meals.map((e) => e.toJson()).toList(),
+      'totals': totals.toJson(),
+    };
   }
 }

--- a/mobapp/lib/screens/diet_detail_screen.dart
+++ b/mobapp/lib/screens/diet_detail_screen.dart
@@ -9,6 +9,7 @@ import '../../extensions/extension_util/string_extensions.dart';
 import '../../extensions/extension_util/widget_extensions.dart';
 import '../../models/diet_response.dart';
 import '../components/HtmlWidget.dart';
+import '../components/meal_plan_view.dart';
 import '../extensions/constants.dart';
 import '../extensions/decorations.dart';
 import '../extensions/system_utils.dart';
@@ -253,7 +254,7 @@ class _DietDetailScreenState extends State<DietDetailScreen> {
   }
 
   Widget ingredients() {
-    return HtmlWidget(postContent: widget.dietModel!.ingredients.toString()).paddingSymmetric(horizontal: 8);
+    return MealPlanView(days: widget.dietModel!.mealPlan ?? [], padding: EdgeInsets.symmetric(horizontal: 16));
   }
 
   Widget instruction() {


### PR DESCRIPTION
## Summary
- introduce reusable meal plan normalization utilities and trait helpers for detailed macro calculations
- update diet resources, controllers, and dashboard form to capture decimal ingredient quantities and expose full plan details
- refresh Flutter models and UI to render assigned diet plans with day/meal breakdowns, circular ingredient imagery, and empty-state messaging

## Testing
- php vendor/bin/phpunit --testsuite=Unit --dont-report-useless-tests

------
https://chatgpt.com/codex/tasks/task_e_68e4cefed6a4832c9d1510a2957c839b