### PR TITLE
Fix meal plan view dependencies

### DIFF
--- a/mobapp/lib/components/meal_plan_view.dart
+++ b/mobapp/lib/components/meal_plan_view.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:nb_utils/nb_utils.dart';
 
+import '../extensions/decorations.dart';
+import '../extensions/text_styles.dart';
 import '../main.dart';
 import '../models/diet_response.dart';
-import '../extensions/widgets.dart';
+import '../utils/app_common.dart';
+import '../extensions/extension_util/context_extensions.dart';
+import '../extensions/extension_util/int_extensions.dart';
+import '../extensions/extension_util/string_extensions.dart';
+import '../extensions/extension_util/widget_extensions.dart';
 
 class MealPlanView extends StatelessWidget {
   final List<MealPlanDay> days;
@@ -27,7 +32,7 @@ class MealPlanView extends StatelessWidget {
     );
 
     if (padding != null) {
-      content = content.padding(padding!);
+      content = Padding(padding: padding!, child: content);
     }
 
     return content;


### PR DESCRIPTION
## Summary
- replace the nb_utils dependency in the meal plan view with local extension imports
- wrap the optional padding in a Padding widget so the screen no longer relies on nb_utils helpers

## Testing
- not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4ddfd7ce0832cac3a0de40077a198