### PR TITLE
Fix analysis errors in Flutter mobile module

### DIFF
--- a/mobapp/lib/network/rest_api.dart
+++ b/mobapp/lib/network/rest_api.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 import 'package:mighty_fitness/languageConfiguration/ServerLanguageResponse.dart';
 import 'package:mighty_fitness/models/FitBotListResponse.dart';
 import 'package:mighty_fitness/models/FitBotSaveDataResponse.dart';
@@ -12,6 +12,7 @@ import '../../models/graph_response.dart';
 import '../../models/level_response.dart';
 import '../../extensions/extension_util/int_extensions.dart';
 import '../../extensions/extension_util/string_extensions.dart';
+import '../extensions/constants.dart';
 import '../extensions/shared_pref.dart';
 import '../main.dart';
 import '../models/payment_list_model.dart';
@@ -51,7 +52,7 @@ import '../models/user_attachment.dart';
 import 'network_utils.dart';
 
 Future<LoginResponse> logInApi(request) async {
-  Response response = await buildHttpResponse('login', request: request, method: HttpMethod.POST);
+  http.Response response = await buildHttpResponse('login', request: request, method: HttpMethod.POST);
   if (!response.statusCode.isSuccessful()) {
     if (response.body.isJson()) {
       var json = jsonDecode(response.body);

--- a/mobapp/lib/screens/progress_screen.dart
+++ b/mobapp/lib/screens/progress_screen.dart
@@ -19,6 +19,7 @@ import '../../extensions/extension_util/int_extensions.dart';
 import '../../extensions/extension_util/widget_extensions.dart';
 import '../../extensions/extension_util/string_extensions.dart';
 import '../extensions/app_button.dart';
+import '../extensions/app_text_field.dart';
 import '../extensions/common.dart';
 import '../extensions/constants.dart';
 import '../../screens/progress_detail_screen.dart';
@@ -181,7 +182,7 @@ class ProgressScreenState extends State<ProgressScreen> {
       _isUpdatingHealth = true;
     });
 
-    final payload = {
+    final Map<String, dynamic> payload = {
       'disliked_ingredients':
           dislikedItems.map((e) => e.id).whereType<int>().toList(),
       'diseases': conditionItems

--- a/mobapp/lib/screens/view_all_diet.dart
+++ b/mobapp/lib/screens/view_all_diet.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import '../../extensions/extension_util/context_extensions.dart';
+import '../../extensions/extension_util/int_extensions.dart';
 import '../../extensions/extension_util/string_extensions.dart';
 import '../../extensions/extension_util/widget_extensions.dart';
 import '../../extensions/decorations.dart';
+import '../../extensions/text_styles.dart';
 import '../../extensions/widgets.dart';
 import '../components/adMob_component.dart';
 import '../components/featured_diet_component.dart';
@@ -14,6 +16,7 @@ import '../models/category_diet_response.dart';
 import '../models/diet_response.dart';
 import '../network/rest_api.dart';
 import '../utils/app_common.dart';
+import '../utils/app_colors.dart';
 import 'no_data_screen.dart';
 
 class ViewAllDiet extends StatefulWidget {

--- a/mobapp/lib/utils/json_utils.dart
+++ b/mobapp/lib/utils/json_utils.dart
@@ -56,3 +56,21 @@ String? parseStringFromJson(dynamic value) {
 
   return value.toString();
 }
+
+/// Safely converts dynamic json values to a [double].
+///
+/// Accepts numeric values and strings that can be parsed into a double.
+/// Returns `null` when conversion isn't possible instead of throwing.
+double? parseDouble(dynamic value) {
+  if (value == null) return null;
+
+  if (value is num) return value.toDouble();
+
+  if (value is String) {
+    final normalised = value.trim();
+    if (normalised.isEmpty) return null;
+    return double.tryParse(normalised);
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a reusable JSON double parser to handle nullable numeric values
- correct imports and payload typing that were causing analyzer errors
- ensure diet assignment UI has the required style utilities available

## Testing
- Not run (Flutter SDK is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e4e06e7748832ca5608d6647ef153f