### PR TITLE
Add type filter to clinic appointments list

### DIFF
--- a/app/Http/Controllers/ClinicAppointmentController.php
+++ b/app/Http/Controllers/ClinicAppointmentController.php
@@ -27,15 +27,23 @@ class ClinicAppointmentController extends Controller
         }
     }
 
-    public function index()
+    public function index(Request $request)
     {
         $this->authorizeAccess();
 
+        $request->validate([
+            'type' => 'nullable|in:regular,free,manual_free',
+        ]);
+
         $pageTitle = __('message.list_form_title', ['form' => __('message.appointment')]);
         $appointments = SpecialistAppointment::with(['user', 'specialist.branch'])
+            ->when($request->filled('type'), function ($query) use ($request) {
+                $query->where('type', $request->input('type'));
+            })
             ->orderByDesc('appointment_date')
             ->orderByDesc('appointment_time')
-            ->paginate(20);
+            ->paginate(20)
+            ->appends($request->only('type'));
 
         $users = User::where('user_type', 'user')
             ->orderBy('display_name')

--- a/resources/lang/ar/message.php
+++ b/resources/lang/ar/message.php
@@ -330,6 +330,7 @@ return [
     'speed' => 'سرعة',
     'Calories' => 'سعرات حرارية',
     'type' => 'يكتب',
+    'all_types' => 'جميع الأنواع',
     'equipment_id' => 'معرف المعدات',
     'days' => 'أيام',
     'about_user' => 'حول المستخدم',

--- a/resources/lang/en/message.php
+++ b/resources/lang/en/message.php
@@ -334,6 +334,7 @@ return [
     'speed' => 'Speed',
     'Calories' => 'Calories',
     'type' => 'Type',
+    'all_types' => 'All Types',
     'equipment_id' => 'Equipment Id',
     'days' => 'Days',
     'about_user' => 'About User',

--- a/resources/views/clinic/appointments/index.blade.php
+++ b/resources/views/clinic/appointments/index.blade.php
@@ -20,6 +20,23 @@
                         @if(session('success'))
                             <div class="alert alert-success">{{ session('success') }}</div>
                         @endif
+                        <form method="GET" class="row g-2 align-items-end mb-4">
+                            <div class="col-sm-6 col-md-4 col-lg-3">
+                                <label class="form-label" for="filter-type">{{ __('message.type') }}</label>
+                                <select class="form-select" id="filter-type" name="type">
+                                    <option value="">{{ __('message.all_types') }}</option>
+                                    <option value="regular" @selected(request('type') === 'regular')>{{ __('message.regular_appointment') }}</option>
+                                    <option value="free" @selected(request('type') === 'free')>{{ __('message.free_appointment') }}</option>
+                                    <option value="manual_free" @selected(request('type') === 'manual_free')>{{ __('message.manual_free_appointment') }}</option>
+                                </select>
+                            </div>
+                            <div class="col-sm-6 col-md-4 col-lg-2">
+                                <button type="submit" class="btn btn-primary w-100">{{ __('message.apply_filter') }}</button>
+                            </div>
+                            <div class="col-sm-6 col-md-4 col-lg-2">
+                                <a href="{{ route('clinic.appointments.index') }}" class="btn btn-outline-secondary w-100">{{ __('message.reset_filter') }}</a>
+                            </div>
+                        </form>
                         <div class="table-responsive">
                             <table class="table table-striped">
                                 <thead>


### PR DESCRIPTION
## Summary
- validate optional appointment type filter in the clinic appointments controller and keep the filter while paginating
- expose a type dropdown with apply/reset actions on the appointments index view
- add translations for the new "all types" label in English and Arabic

## Testing
- php artisan test *(fails: Please provide a valid cache path.)*

------
https://chatgpt.com/codex/tasks/task_e_68e4edf06344832cac75b44b5d417502