### PR TITLE
Display assigned diet details on mobile diet screen

### DIFF
--- a/mobapp/lib/components/meal_plan_view.dart
+++ b/mobapp/lib/components/meal_plan_view.dart
@@ -69,6 +69,8 @@ class MealPlanView extends StatelessWidget {
     final mealTitle = appStore.selectedLanguageCode == 'ar'
         ? 'الوجبة ${meal.mealNumber}'
         : 'Meal ${meal.mealNumber}';
+    final mealTimeLabel = appStore.selectedLanguageCode == 'ar' ? 'الوقت' : 'Time';
+    final hasMealTime = meal.time.validate().isNotEmpty;
 
     return Container(
       margin: EdgeInsets.only(bottom: 16),
@@ -77,14 +79,18 @@ class MealPlanView extends StatelessWidget {
         borderRadius: radius(12),
       ),
       padding: EdgeInsets.all(12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(mealTitle, style: boldTextStyle()),
-          12.height,
-          Column(
-            children: meal.ingredients.map((ingredient) => _buildIngredientTile(context, ingredient)).toList(),
-          ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(mealTitle, style: boldTextStyle()),
+            if (hasMealTime) ...[
+              6.height,
+              Text('$mealTimeLabel: ${meal.time.validate()}', style: secondaryTextStyle()),
+            ],
+            12.height,
+            Column(
+              children: meal.ingredients.map((ingredient) => _buildIngredientTile(context, ingredient)).toList(),
+            ),
           12.height,
           _buildTotalsRow(context, meal.totals, showLabel: true),
         ],

--- a/mobapp/lib/models/diet_response.dart
+++ b/mobapp/lib/models/diet_response.dart
@@ -355,10 +355,11 @@ class MealPlanIngredientDetail {
 
 class MealPlanMeal {
   int mealNumber;
+  String? time;
   List<MealPlanIngredientDetail> ingredients;
   MealPlanTotals totals;
 
-  MealPlanMeal({required this.mealNumber, required this.ingredients, required this.totals});
+  MealPlanMeal({required this.mealNumber, this.time, required this.ingredients, required this.totals});
 
   factory MealPlanMeal.fromJson(Map<String, dynamic>? json) {
     json ??= {};
@@ -367,6 +368,7 @@ class MealPlanMeal {
 
     return MealPlanMeal(
       mealNumber: _parseInt(json['meal_number']),
+      time: json['time']?.toString(),
       ingredients: ingredientsJson
           .map((ingredient) => MealPlanIngredientDetail.fromJson(_ensureMap(ingredient)))
           .whereType<MealPlanIngredientDetail>()
@@ -378,6 +380,7 @@ class MealPlanMeal {
   Map<String, dynamic> toJson() {
     return {
       'meal_number': mealNumber,
+      'time': time,
       'ingredients': ingredients.map((e) => e.toJson()).toList(),
       'totals': totals.toJson(),
     };


### PR DESCRIPTION
## Summary
- load the assigned diet list when the diet tab opens and surface the meal plan or a friendly empty state
- reuse the meal plan component to render meal times, ingredients, and macro totals inside the assigned diet cards
- extend the diet response model to carry meal timing information consumed by the UI

## Testing
- flutter test *(fails: flutter command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eef118b4832c8d1c04bd9f62b992