### PR TITLE
Fix assign diet modal ingredient options serialization

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -548,6 +548,16 @@ class UserController extends Controller
                 ->all()
             : [];
 
+        $ingredientOptions = $ingredients
+            ->map(function (Ingredient $ingredient) use ($dislikedIngredientIds) {
+                return [
+                    'id' => (int) $ingredient->id,
+                    'title' => $ingredient->title,
+                    'disliked' => in_array($ingredient->id, $dislikedIngredientIds, true),
+                ];
+            })
+            ->values();
+
         $customPlan = $assignment->custom_plan ?? [];
 
         $view = view('users.edit_assign_diet', [
@@ -559,6 +569,7 @@ class UserController extends Controller
             'ingredients' => $ingredients,
             'ingredientsMap' => $ingredientsMap,
             'dislikedIngredientIds' => $dislikedIngredientIds,
+            'ingredientOptions' => $ingredientOptions,
         ])->render();
 
         return response()->json(['data' => $view, 'status' => true]);

--- a/resources/views/users/edit_assign_diet.blade.php
+++ b/resources/views/users/edit_assign_diet.blade.php
@@ -235,13 +235,7 @@
         {{ html()->form()->close() }}
     @endif
 <script>
-    window.dietMealIngredientOptions = @json($ingredients->map(function ($ingredient) use ($dislikedIngredientIds) {
-        return [
-            'id' => (int) $ingredient->id,
-            'title' => $ingredient->title,
-            'disliked' => in_array($ingredient->id, $dislikedIngredientIds, true),
-        ];
-    })->values());
+    window.dietMealIngredientOptions = @json($ingredientOptions ?? []);
     window.dietMealIngredientPlaceholder = @json(__('message.select_name', ['select' => __('message.ingredient')]));
     window.dietMealIngredientQuantityLabel = @json(__('message.quantity'));
     window.dietMealIngredientRemoveLabel = @json(__('message.remove'));

--- a/tests/Feature/EditAssignDietViewTest.php
+++ b/tests/Feature/EditAssignDietViewTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AssignDiet;
+use App\Models\Diet;
+use App\Models\Ingredient;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class EditAssignDietViewTest extends TestCase
+{
+    public function test_edit_assign_diet_view_renders_with_ingredient_options(): void
+    {
+        $assignment = AssignDiet::make([
+            'user_id' => 1,
+            'diet_id' => 1,
+        ]);
+
+        $diet = Diet::make([
+            'id' => 1,
+            'title' => 'Sample Diet',
+            'servings' => 2,
+            'days' => 2,
+        ]);
+
+        $ingredients = Collection::make([
+            tap(Ingredient::make(['title' => 'Oats']), fn ($ingredient) => $ingredient->id = 1),
+            tap(Ingredient::make(['title' => 'Yogurt']), fn ($ingredient) => $ingredient->id = 2),
+        ]);
+
+        $ingredientOptions = $ingredients->map(function (Ingredient $ingredient) {
+            return [
+                'id' => $ingredient->id,
+                'title' => $ingredient->title,
+                'disliked' => false,
+            ];
+        })->values();
+
+        $session = app('session.store');
+        $session->start();
+        app('request')->setLaravelSession($session);
+
+        $html = view('users.edit_assign_diet', [
+            'assignment' => $assignment,
+            'diet' => $diet,
+            'plan' => [
+                [
+                    [
+                        ['id' => 1, 'quantity' => 1],
+                    ],
+                ],
+            ],
+            'maxMeals' => 1,
+            'customPlan' => [],
+            'ingredients' => $ingredients,
+            'ingredientsMap' => $ingredients->keyBy('id'),
+            'dislikedIngredientIds' => [],
+            'ingredientOptions' => $ingredientOptions,
+        ])->render();
+
+        $this->assertStringContainsString('data-action="add-meal-ingredient"', $html);
+        $this->assertStringContainsString('window.dietMealIngredientOptions', $html);
+    }
+}


### PR DESCRIPTION
## Summary
- build the ingredient option payload in the controller to avoid Blade json directive parsing issues
- read the precomputed options in the edit assign diet view when bootstrapping the editor
- cover the modal rendering path with a view-focused feature test

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=/workspace/fit/database/database.sqlite php artisan test --filter=EditAssignDietViewTest`


------
https://chatgpt.com/codex/tasks/task_e_68e4f0f52410832c9408d4a1888e100d