### PR TITLE
Fix assigned diet filtering for mobile clients

### DIFF
--- a/app/Http/Controllers/API/AssignUserController.php
+++ b/app/Http/Controllers/API/AssignUserController.php
@@ -16,9 +16,13 @@ class AssignUserController extends Controller
 {
     public function getAssignDiet(Request $request)
     {
-        $assign_diet = Diet::myAssignDiet()
-            ->with(['userAssignDiet' => function ($query) {
-                $query->where('user_id', auth()->id());
+        $userId = auth()->id();
+
+        $assign_diet = Diet::myAssignDiet($userId)
+            ->with(['userAssignDiet' => function ($query) use ($userId) {
+                if ($userId) {
+                    $query->where('user_id', $userId);
+                }
             }]);
         
         $per_page = config('constant.PER_PAGE_LIMIT');

--- a/app/Models/Diet.php
+++ b/app/Models/Diet.php
@@ -60,12 +60,13 @@ class Diet extends Model implements HasMedia
         return $query;
     }
 
-    public function scopeMyAssignDiet($query, $user_id =null)
+    public function scopeMyAssignDiet($query, $user_id = null)
     {
-        $user = auth()->user();
-        if($user->hasRole(['user'])){
-            $query = $query->whereHas('userAssignDiet', function ($q) use($user) {
-                $q->where('user_id', $user->id);
+        $userId = $user_id ?? optional(auth()->user())->id;
+
+        if ($userId) {
+            $query = $query->whereHas('userAssignDiet', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
             });
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,8 +21,8 @@
         <server name="APP_ENV" value="testing"/>
         <server name="BCRYPT_ROUNDS" value="4"/>
         <server name="CACHE_DRIVER" value="array"/>
-        <!-- <server name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <server name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_MAILER" value="array"/>
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/AssignDietApiTest.php
+++ b/tests/Feature/AssignDietApiTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AssignDiet;
+use App\Models\CategoryDiet;
+use App\Models\Diet;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AssignDietApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    public function test_scope_my_assign_diet_returns_diets_for_given_user()
+    {
+        $role = Role::create([
+            'name' => 'user',
+            'title' => 'User',
+            'status' => 1,
+            'guard_name' => 'web',
+        ]);
+
+        $user = User::create([
+            'username' => 'member',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'phone_number' => null,
+            'status' => 'active',
+            'email' => 'user@example.com',
+            'password' => Hash::make('password'),
+            'gender' => 'male',
+            'display_name' => 'Test User',
+            'login_type' => 'email',
+            'user_type' => 'user',
+            'player_id' => null,
+            'is_subscribe' => 0,
+            'timezone' => 'UTC',
+            'last_notification_seen' => null,
+        ]);
+
+        $otherUser = User::create([
+            'username' => 'member2',
+            'first_name' => 'Other',
+            'last_name' => 'User',
+            'phone_number' => null,
+            'status' => 'active',
+            'email' => 'other@example.com',
+            'password' => Hash::make('password'),
+            'gender' => 'male',
+            'display_name' => 'Other User',
+            'login_type' => 'email',
+            'user_type' => 'user',
+            'player_id' => null,
+            'is_subscribe' => 0,
+            'timezone' => 'UTC',
+            'last_notification_seen' => null,
+        ]);
+
+        $user->assignRole($role);
+        $otherUser->assignRole($role);
+
+        $category = CategoryDiet::create([
+            'title' => 'General',
+            'slug' => 'general',
+            'status' => 'active',
+        ]);
+
+        $diet = Diet::create([
+            'title' => 'Sample Diet',
+            'slug' => 'sample-diet',
+            'categorydiet_id' => $category->id,
+            'calories' => '100',
+            'carbs' => '10',
+            'protein' => '5',
+            'fat' => '2',
+            'servings' => 1,
+            'days' => 1,
+            'total_time' => '10',
+            'is_featured' => '0',
+            'status' => 'active',
+            'ingredients' => [],
+            'description' => 'Sample description',
+            'is_premium' => 0,
+        ]);
+
+        AssignDiet::create([
+            'user_id' => $user->id,
+            'diet_id' => $diet->id,
+            'serve_times' => ['08:00'],
+        ]);
+
+        AssignDiet::create([
+            'user_id' => $otherUser->id,
+            'diet_id' => $diet->id,
+            'serve_times' => ['09:00'],
+        ]);
+
+        $results = Diet::myAssignDiet($user->id)->get();
+
+        $this->assertCount(1, $results);
+        $this->assertTrue($results->first()->is($diet));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure the assigned diet API always filters results by the authenticated user id
- update the Diet::myAssignDiet scope to accept an explicit user id fallback when no guard context is available
- enable the in-memory sqlite connection for tests and add a regression test covering the scope behaviour

## Testing
- php artisan test --testsuite=Feature --filter=AssignDietApiTest

------
https://chatgpt.com/codex/tasks/task_e_68e4f7b8994c832ca618663efa44ec1f