### PR TITLE
Fix manual free slot validation for schedule mapping

### DIFF
--- a/app/Http/Controllers/ClinicAppointmentController.php
+++ b/app/Http/Controllers/ClinicAppointmentController.php
@@ -206,8 +206,10 @@ class ClinicAppointmentController extends Controller
         $date = Carbon::createFromFormat('Y-m-d', $data['appointment_date']);
         $time = Carbon::createFromFormat('H:i', $data['appointment_time'])->format('H:i:s');
 
+        $scheduleDay = ($date->dayOfWeek + 6) % 7;
+
         $scheduleExists = SpecialistSchedule::where('specialist_id', $specialist->id)
-            ->where('day_of_week', $date->dayOfWeek)
+            ->where('day_of_week', $scheduleDay)
             ->where('start_time', '<=', $time)
             ->where('end_time', '>', $time)
             ->exists();

--- a/app/Http/Controllers/ClinicFreeBookingRequestController.php
+++ b/app/Http/Controllers/ClinicFreeBookingRequestController.php
@@ -68,8 +68,10 @@ class ClinicFreeBookingRequestController extends Controller
             $date = Carbon::createFromFormat('Y-m-d', $request->appointment_date);
             $time = Carbon::createFromFormat('H:i', $request->appointment_time)->format('H:i:s');
 
+            $scheduleDay = ($date->dayOfWeek + 6) % 7;
+
             $scheduleExists = SpecialistSchedule::where('specialist_id', $request->specialist_id)
-                ->where('day_of_week', $date->dayOfWeek)
+                ->where('day_of_week', $scheduleDay)
                 ->where('start_time', '<=', $time)
                 ->where('end_time', '>', $time)
                 ->exists();


### PR DESCRIPTION
## Summary
- normalise the day-of-week check when validating specialist schedules so manual free appointments match stored schedule values
- apply the same normalisation when converting free booking requests into appointments

## Testing
- php artisan test *(fails: application lacks auth routes and factories in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e500ce8c40832c9416074bf81147e0