### PR TITLE
Fix API payload for assigned diets and add regression test

### DIFF
--- a/app/Http/Controllers/API/AssignUserController.php
+++ b/app/Http/Controllers/API/AssignUserController.php
@@ -38,13 +38,16 @@ class AssignUserController extends Controller
 
         $assign_diet = $assign_diet->orderBy('id', 'desc')->paginate($per_page);
 
-        $items = DietResource::collection($assign_diet);
+        $data = collect($assign_diet->items())
+            ->map(fn ($diet) => (new DietResource($diet))->toArray($request))
+            ->values()
+            ->all();
 
         $response = [
-            'pagination'    => json_pagination_response($items),
-            'data'          => $items,
+            'pagination'    => json_pagination_response($assign_diet),
+            'data'          => $data,
         ];
-        
+
         return json_custom_response($response);
     }
 
@@ -65,14 +68,17 @@ class AssignUserController extends Controller
 
         $assign_workout = $assign_workout->orderBy('id', 'desc')->paginate($per_page);
 
-        $items = WorkoutResource::collection($assign_workout);
+        $data = collect($assign_workout->items())
+            ->map(fn ($workout) => (new WorkoutResource($workout))->toArray($request))
+            ->values()
+            ->all();
 
         $response = [
-            'pagination'    => json_pagination_response($items),
-            'data'          => $items,
+            'pagination'    => json_pagination_response($assign_workout),
+            'data'          => $data,
         ];
-        
+
         return json_custom_response($response);
-    } 
-      
+    }
+
 }

--- a/tests/Feature/AssignDietApiTest.php
+++ b/tests/Feature/AssignDietApiTest.php
@@ -9,6 +9,8 @@ use App\Models\Role;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class AssignDietApiTest extends TestCase
@@ -110,6 +112,81 @@ class AssignDietApiTest extends TestCase
 
         $this->assertCount(1, $results);
         $this->assertTrue($results->first()->is($diet));
+    }
+
+    public function test_assign_diet_api_returns_flattened_resource_list()
+    {
+        $role = Role::create([
+            'name' => 'user',
+            'title' => 'User',
+            'status' => 1,
+            'guard_name' => 'web',
+        ]);
+
+        $user = User::create([
+            'username' => 'member',
+            'first_name' => 'Test',
+            'last_name' => 'User',
+            'phone_number' => null,
+            'status' => 'active',
+            'email' => 'user@example.com',
+            'password' => Hash::make('password'),
+            'gender' => 'male',
+            'display_name' => 'Test User',
+            'login_type' => 'email',
+            'user_type' => 'user',
+            'player_id' => null,
+            'is_subscribe' => 0,
+            'timezone' => 'UTC',
+            'last_notification_seen' => null,
+        ]);
+
+        $user->assignRole($role);
+
+        $category = CategoryDiet::create([
+            'title' => 'General',
+            'slug' => 'general',
+            'status' => 'active',
+        ]);
+
+        $diet = Diet::create([
+            'title' => 'Sample Diet',
+            'slug' => 'sample-diet',
+            'categorydiet_id' => $category->id,
+            'calories' => '100',
+            'carbs' => '10',
+            'protein' => '5',
+            'fat' => '2',
+            'servings' => 1,
+            'days' => 1,
+            'total_time' => '10',
+            'is_featured' => '0',
+            'status' => 'active',
+            'ingredients' => [],
+            'description' => 'Sample description',
+            'is_premium' => 0,
+        ]);
+
+        AssignDiet::create([
+            'user_id' => $user->id,
+            'diet_id' => $diet->id,
+            'serve_times' => ['08:00'],
+        ]);
+
+        Sanctum::actingAs($user);
+
+        $request = Request::create('/api/assign-diet-list', 'GET');
+
+        $response = app(\App\Http\Controllers\API\AssignUserController::class)->getAssignDiet($request);
+
+        $payload = $response->getData(true);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(1, $payload['pagination']['total_items']);
+        $this->assertIsArray($payload['data']);
+        $this->assertArrayNotHasKey('data', $payload['data']);
+        $this->assertSame($diet->id, $payload['data'][0]['id']);
+        $this->assertSame($diet->title, $payload['data'][0]['title']);
     }
 }
 


### PR DESCRIPTION
## Summary
- flatten the assigned diet and workout API payloads so the mobile app receives simple arrays
- add a regression test that exercises the assign-diet-list endpoint response structure

## Testing
- php artisan test --filter=AssignDietApiTest

------
https://chatgpt.com/codex/tasks/task_e_68e503410e7c832c819d7a2a36a67e7d